### PR TITLE
Remote work

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -65,3 +65,4 @@ config.local.yaml
 activate_dev.sh
 qdashboard/tests/
 ping_electronics.sh
+DESIGN_SYSTEM.md

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -54,7 +54,8 @@ dependencies = [
     "pathlib2>=2.3.0",
     "PyYAML>=6.0.0",
     "python-dotenv>=1.0.0",
-    "packaging>=23.0"
+    "packaging>=23.0",
+    "asyncssh>=2.14.0"
 ]
 
 [project.optional-dependencies]

--- a/qdashboard/assets/css/dashboard.css
+++ b/qdashboard/assets/css/dashboard.css
@@ -2,53 +2,53 @@ body {
     overflow-x: hidden;
     background-color: var(--vsc-bg);
     color: var(--vsc-text);
-    font-family: 'IBM Plex Sans', sans-serif;
-    font-size: 0.875rem; /* Smaller, more compact size */
+    font-family: var(--font-family-base);
+    font-size: var(--font-size-base); /* Smaller, more compact size */
 }
 
 h1 {
-    font-size: 1.5rem; 
+    font-size: var(--font-size-3xl); 
 }
 
 h2 {
-    font-size: 1.4rem;
+    font-size: var(--font-size-2xl);
 }
 
 h3 {
-    font-size: 1.25rem; 
+    font-size: var(--font-size-xl); 
 }
 
 h4 {
-    font-size: 1.125rem; 
+    font-size: var(--font-size-lg); 
 }
 
 h5 {
-    font-size: 1rem; 
+    font-size: var(--font-size-md); 
 }
 
 .card-title {
-    font-size: 1rem; 
+    font-size: var(--font-size-md); 
 }
 
 .breadcrumb {
-    font-size: 0.8rem; /* Smaller breadcrumb text */
+    font-size: var(--font-size-sm); /* Smaller breadcrumb text */
 }
 
 .table {
-    font-size: 0.8rem; /* Smaller table text */
+    font-size: var(--font-size-sm); /* Smaller table text */
 }
 
 .btn {
-    font-size: 0.8rem; /* Smaller button text */
+    font-size: var(--font-size-sm); /* Smaller button text */
     padding: 0.375rem 0.75rem; /* Adjusted padding */
 }
 
 .log-box {
-    font-size: 0.75rem; /* Smaller log text */
+    font-size: var(--font-size-xs); /* Smaller log text */
 }
 
 .modal-title {
-    font-size: 1.125rem; /* Smaller modal titles */
+    font-size: var(--font-size-lg); /* Smaller modal titles */
 }
 
 /*
@@ -119,7 +119,7 @@ to ensure consistency across all pages.
     padding: 10px;
     height: 300px;
     overflow-y: scroll;
-    font-family: monospace;
+    font-family: var(--font-family-mono);
 }
 
 .card-link {
@@ -442,28 +442,28 @@ to ensure consistency across all pages.
 /* Dashboard Page Specific Overrides */
 /* Override listr.pack.css conflicting styles */
 .dashboard-page {
-    font-family: 'IBM Plex Sans', sans-serif !important;
-    font-size: 0.875rem !important;
+    font-family: var(--font-family-base) !important;
+    font-size: var(--font-size-base) !important;
 }
 
 .dashboard-page h1 {
-    font-size: 1.75rem !important;
+    font-size: var(--font-size-4xl) !important;
     color: #f0f0f0 !important;
-    font-family: 'IBM Plex Sans', sans-serif !important;
+    font-family: var(--font-family-base) !important;
 }
 
 .dashboard-page .card-header {
     background-color: #2a2a2a !important;
     border-color: #444 !important;
     color: #f0f0f0 !important;
-    font-size: 0.875rem !important;
+    font-size: var(--font-size-base) !important;
 }
 
 .dashboard-page .breadcrumb {
     background-color: transparent !important;
     margin-bottom: 0 !important;
-    font-size: 0.8rem !important;
-    font-family: 'IBM Plex Sans', sans-serif !important;
+    font-size: var(--font-size-sm) !important;
+    font-family: var(--font-family-base) !important;
 }
 
 .dashboard-page .breadcrumb a {
@@ -475,8 +475,8 @@ to ensure consistency across all pages.
 }
 
 .dashboard-page .table {
-    font-size: 0.8rem !important;
-    font-family: 'IBM Plex Sans', sans-serif !important;
+    font-size: var(--font-size-sm) !important;
+    font-family: var(--font-family-base) !important;
 }
 
 .dashboard-page .table a {
@@ -488,24 +488,24 @@ to ensure consistency across all pages.
 }
 
 .dashboard-page .btn {
-    font-size: 0.8rem !important;
-    font-family: 'IBM Plex Sans', sans-serif !important;
+    font-size: var(--font-size-sm) !important;
+    font-family: var(--font-family-base) !important;
     padding: 0.375rem 0.75rem !important;
 }
 
 .dashboard-page .form-control {
-    font-size: 0.875rem !important;
-    font-family: 'IBM Plex Sans', sans-serif !important;
+    font-size: var(--font-size-base) !important;
+    font-family: var(--font-family-base) !important;
 }
 
 .dashboard-page .modal-title {
-    font-size: 1.125rem !important;
-    font-family: 'IBM Plex Sans', sans-serif !important;
+    font-size: var(--font-size-lg) !important;
+    font-family: var(--font-family-base) !important;
     color: #f0f0f0 !important;
 }
 
 .dashboard-page .modal-body {
-    font-family: 'IBM Plex Sans', sans-serif !important;
+    font-family: var(--font-family-base) !important;
 }
 
 /* Override any inherited text colors */
@@ -526,8 +526,8 @@ to ensure consistency across all pages.
 
 /* Report Viewer Specific Overrides */
 .dashboard-page .report-content {
-    font-family: 'IBM Plex Sans', sans-serif !important;
-    font-size: 0.875rem !important;
+    font-family: var(--font-family-base) !important;
+    font-size: var(--font-size-base) !important;
 }
 
 .dashboard-page .report-content h1,
@@ -536,28 +536,28 @@ to ensure consistency across all pages.
 .dashboard-page .report-content h4,
 .dashboard-page .report-content h5,
 .dashboard-page .report-content h6 {
-    font-family: 'IBM Plex Sans', sans-serif !important;
+    font-family: var(--font-family-base) !important;
     color: #f0f0f0 !important;
 }
 
 .dashboard-page .report-content h1 {
-    font-size: 1.75rem !important;
+    font-size: var(--font-size-4xl) !important;
 }
 
 .dashboard-page .report-content h2 {
-    font-size: 1.5rem !important;
+    font-size: var(--font-size-3xl) !important;
 }
 
 .dashboard-page .report-content h3 {
-    font-size: 1.25rem !important;
+    font-size: var(--font-size-xl) !important;
 }
 
 .dashboard-page .report-content h4 {
-    font-size: 1.125rem !important;
+    font-size: var(--font-size-lg) !important;
 }
 
 .dashboard-page .report-content h5 {
-    font-size: 1rem !important;
+    font-size: var(--font-size-md) !important;
 }
 
 .dashboard-page .report-content p,
@@ -565,18 +565,18 @@ to ensure consistency across all pages.
 .dashboard-page .report-content span,
 .dashboard-page .report-content td,
 .dashboard-page .report-content th {
-    font-family: 'IBM Plex Sans', sans-serif !important;
-    font-size: 0.875rem !important;
+    font-family: var(--font-family-base) !important;
+    font-size: var(--font-size-base) !important;
     color: #f0f0f0 !important;
 }
 
 .dashboard-page .report-content table {
-    font-size: 0.8rem !important;
+    font-size: var(--font-size-sm) !important;
 }
 
 .dashboard-page .report-content pre,
 .dashboard-page .report-content code {
-    font-size: 0.75rem !important;
+    font-size: var(--font-size-xs) !important;
     background-color: #2a2a2a !important;
     color: #f0f0f0 !important;
 }
@@ -592,7 +592,7 @@ to ensure consistency across all pages.
 /* SLURM Queue Table Styling */
 .table .btn-sm {
     padding: 0.25rem 0.375rem !important;
-    font-size: 0.7rem !important;
+    font-size: var(--font-size-xs) !important;
     line-height: 1.2 !important;
 }
 
@@ -619,22 +619,22 @@ to ensure consistency across all pages.
 
 /* Platform Information Card Specific Styling */
 .platform-info-card .form-control {
-    font-size: 0.875rem !important;
-    font-family: 'IBM Plex Sans', sans-serif !important;
+    font-size: var(--font-size-base) !important;
+    font-family: var(--font-family-base) !important;
 }
 
 .platform-info-card .btn {
-    font-size: 0.8rem !important;
-    font-family: 'IBM Plex Sans', sans-serif !important;
+    font-size: var(--font-size-sm) !important;
+    font-family: var(--font-family-base) !important;
 }
 
 .platform-info-card select.form-control {
-    font-size: 0.875rem !important;
+    font-size: var(--font-size-base) !important;
     padding: 0.375rem 0.75rem !important;
 }
 
 .platform-info-card .input-group .btn {
-    font-size: 0.8rem !important;
+    font-size: var(--font-size-sm) !important;
     padding: 0.375rem 0.75rem !important;
 }
 
@@ -729,7 +729,7 @@ to ensure consistency across all pages.
 .qibocal-report-badge {
     background-color: rgba(23, 162, 184, 0.2);
     color: #17a2b8;
-    font-size: 0.7rem;
+    font-size: var(--font-size-xs);
     padding: 0.2rem 0.4rem;
     border-radius: 0.25rem;
     border: 1px solid rgba(23, 162, 184, 0.4);
@@ -753,7 +753,7 @@ to ensure consistency across all pages.
 }
 
 .qibocal-btn i {
-    font-size: 0.875rem;
+    font-size: var(--font-size-base);
     width: auto;
     margin: 0;
 }
@@ -794,7 +794,7 @@ to ensure consistency across all pages.
 
 #qibocal-status .alert {
     margin-bottom: 0;
-    font-size: 0.875rem;
+    font-size: var(--font-size-base);
 }
 
 #qibocal-status .alert i {

--- a/qdashboard/assets/css/experiments.css
+++ b/qdashboard/assets/css/experiments.css
@@ -86,7 +86,7 @@
         /* Responsive column sizing */
         @media (max-width: 768px) {
             .calibration-table {
-                font-size: 0.75rem !important;
+                font-size: var(--font-size-xs) !important;
             }
             
             .calibration-table th,
@@ -102,7 +102,7 @@
         }
 
         .scm-title {
-            font-size: .78rem;
+            font-size: var(--font-size-xs);
             color: var(--vsc-text-muted);
         }
 
@@ -158,7 +158,7 @@
         }
 
         .category-header .category-icon {
-            font-size: .7rem;
+            font-size: var(--font-size-xs);
             width: 14px;
             color: var(--vsc-text-faint);
             transition: transform 0.2s ease;
@@ -188,13 +188,13 @@
 
         .category-title {
             font-weight: 600;
-            font-size: 0.85rem;
+            font-size: var(--font-size-base);
             margin-bottom: 0;
             color: var(--vsc-text);
         }
 
         .category-count {
-            font-size: 0.7rem;
+            font-size: var(--font-size-xs);
             color: var(--vsc-text-muted);
             font-weight: 500;
             margin-left: 8px;
@@ -230,6 +230,13 @@
             background-color: var(--vsc-bg-hover) !important;
         }
 
+        .experiment-card .fa-flask {
+            font-size: var(--font-size-xs);
+            width: 14px;
+            text-align: center;
+            color: var(--vsc-text-faint);
+        }
+
         .experiment-card[data-toggle="collapse"] .fa-chevron-down {
             transition: transform 0.2s ease;
         }
@@ -255,7 +262,7 @@
             color: #fff;
             padding: 0.1rem 0.3rem;
             border-radius: var(--radius-sm);
-            font-size: 0.8rem;
+            font-size: var(--font-size-sm);
         }
 
         .attribute-item {
@@ -273,19 +280,19 @@
             color: #fff !important;
             padding: 0.2rem 0.4rem;
             border-radius: var(--radius-sm);
-            font-size: 0.8rem;
+            font-size: var(--font-size-sm);
         }
 
         .attribute-type {
-            font-size: 0.75rem;
-            font-family: 'Courier New', monospace;
+            font-size: var(--font-size-xs);
+            font-family: var(--font-family-mono);
             word-wrap: break-word;
             color: var(--vsc-text-muted);
         }
 
         /* Badge styling for tab counts */
         .vsc-tab .badge {
-            font-size: 0.65rem;
+            font-size: var(--font-size-xs);
             padding: 0.2em 0.4em;
         }
         
@@ -369,7 +376,7 @@
             border-left: 3px solid transparent;
             border-bottom: var(--border-hairline);
             color: var(--vsc-text-muted);
-            font-size: 0.78rem;
+            font-size: var(--font-size-xs);
             text-align: left;
             cursor: grab;
             transition: background-color 0.15s ease, color 0.15s ease, border-color 0.15s ease;
@@ -452,7 +459,7 @@
 
         .action-item .form-text {
             color: #adb5bd;
-            font-size: 0.75rem;
+            font-size: var(--font-size-xs);
         }
 
         .action-item .form-check-input:checked {
@@ -501,7 +508,7 @@
 
         .input-label {
             min-width: 120px;
-            font-size: 0.875rem;
+            font-size: var(--font-size-base);
             font-weight: 500;
             color: #adb5bd;
             margin: 0;
@@ -512,7 +519,7 @@
             flex: 1;
             height: 32px !important;
             padding: 0.375rem 0.5rem !important;
-            font-size: 0.875rem !important;
+            font-size: var(--font-size-base) !important;
         }
 
         .compact-input[type="checkbox"] {
@@ -524,7 +531,7 @@
 
         .form-check-label {
             margin-bottom: 0 !important;
-            font-size: 0.875rem;
+            font-size: var(--font-size-base);
             color: #adb5bd;
             cursor: pointer;
         }
@@ -544,7 +551,7 @@
             align-items: center;
             cursor: pointer;
             color: #fff;
-            font-size: 0.875rem;
+            font-size: var(--font-size-base);
             font-weight: 500;
             transition: background-color 0.2s ease;
             user-select: none;
@@ -558,7 +565,7 @@
 
         .protocol-section-header .fa-chevron-down {
             transition: transform 0.2s ease;
-            font-size: 0.75rem;
+            font-size: var(--font-size-xs);
         }
 
         .protocol-section-header[aria-expanded="true"] .fa-chevron-down {
@@ -571,7 +578,7 @@
         }
 
         .protocol-section .badge {
-            font-size: 0.7rem;
+            font-size: var(--font-size-xs);
             padding: 0.2em 0.4em;
         }
 
@@ -585,7 +592,7 @@
 
             .input-label {
                 min-width: auto;
-                font-size: 0.8rem;
+                font-size: var(--font-size-sm);
             }
 
             .compact-input {
@@ -633,11 +640,22 @@
     max-width: 100%;
 }
 
+.panel-builder .card {
+    border-right: none;
+    border-top-right-radius: 0;
+    border-bottom-right-radius: 0;
+}
+.panel-results .card {
+    border-left: none;
+    border-top-left-radius: 0;
+    border-bottom-left-radius: 0;
+}
+
 .panel-builder-resize-handle {
-    flex: 0 0 4px;
-    width: 4px;
+    flex: 0 0 2px;
+    width: 2px;
     cursor: col-resize;
-    background: transparent;
+    background: var(--vsc-border);
 }
 .panel-builder-resize-handle:hover, .panel-builder-resize-handle.resizing {
     background: var(--vsc-accent);
@@ -679,7 +697,7 @@
 #results-error-traceback {
     background: #140d00 !important;
     color: #ffb74d !important;
-    font-size: .68rem !important;
+    font-size: var(--font-size-xs) !important;
     line-height: 1.35;
     max-height: 180px;
     overflow-y: auto;
@@ -700,7 +718,7 @@
 }
 
 #results-report-container {
-    font-size: 0.85rem;
+    font-size: var(--font-size-base);
     flex: 1 1 auto;
     min-height: 0;
 }
@@ -749,13 +767,13 @@
     align-items: center;
 }
 
-.panel-header .font-weight-semibold { font-weight: 600; font-size: .9rem; }
+.panel-header .font-weight-semibold { font-weight: 600; font-size: var(--font-size-base); }
 
 /* Library search input: compact inline */
-#experiment-search { font-size: 0.8rem; }
+#experiment-search { font-size: var(--font-size-sm); }
 
 /* Qubit multi-select: compact */
-#qubit-select option { padding: 1px 4px; font-size: .78rem; }
+#qubit-select option { padding: 1px 4px; font-size: var(--font-size-xs); }
 
 /* Card footer for action nodes */
 .panel-builder .card-footer {
@@ -768,8 +786,8 @@
 .log-viewer {
     background: #0d0d0d !important;
     color: #00e676 !important;
-    font-family: 'Courier New', monospace;
-    font-size: .72rem;
+    font-family: var(--font-family-mono);
+    font-size: var(--font-size-xs);
     line-height: 1.4;
     max-height: calc(100vh - 220px);
     overflow-y: auto;
@@ -802,7 +820,7 @@
 }
 
 .action-param-label {
-    font-size: .71rem;
+    font-size: var(--font-size-xs);
     color: #adb5bd;
     white-space: nowrap;
 }
@@ -811,7 +829,7 @@
     width: 68px !important;
     height: 26px !important;
     padding: .1rem .3rem !important;
-    font-size: .75rem !important;
+    font-size: var(--font-size-xs) !important;
     background: #2a2a2a !important;
     border-color: #555 !important;
     color: #fff !important;
@@ -821,7 +839,7 @@
 .action-target-btn {
     height: 26px;
     padding: .1rem .45rem;
-    font-size: .72rem;
+    font-size: var(--font-size-xs);
     white-space: nowrap;
     border-color: #555;
     color: #ccc;

--- a/qdashboard/assets/css/menu.css
+++ b/qdashboard/assets/css/menu.css
@@ -61,7 +61,7 @@
 /* 2. Sidebar Heading */
 #sidebar-wrapper .sidebar-heading {
     padding: 0.875rem 1.25rem;
-    font-size: 1.2rem;
+    font-size: var(--font-size-lg);
     font-weight: 500; /* Added for emphasis */
     color: #fff;
     border-bottom: 1px solid var(--vsc-border); /* Added for separation */
@@ -136,7 +136,7 @@
     background-color: var(--vsc-bg-elevated);
     border-top: 1px solid var(--vsc-border);
     padding: 0.75rem 1.25rem;
-    font-size: 0.75rem;
+    font-size: var(--font-size-xs);
     color: #999;
     opacity: 0; /* Hidden by default */
     transition: opacity 0.3s ease;
@@ -152,7 +152,7 @@
     color: #ccc;
     font-weight: 600;
     margin-bottom: 0.5rem;
-    font-size: 0.8rem;
+    font-size: var(--font-size-sm);
 }
 
 #sidebar-wrapper .sidebar-footer-versions .version-item {
@@ -170,7 +170,7 @@
 #sidebar-wrapper .sidebar-footer-versions .version-number {
     color: #4dabf7;
     font-weight: 600;
-    font-family: monospace;
+    font-family: var(--font-family-mono);
 }
 
 #sidebar-wrapper .sidebar-footer-versions .version-error {
@@ -192,7 +192,7 @@
 .version-number {
     color: #4dabf7;
     font-weight: 600;
-    font-family: monospace;
+    font-family: var(--font-family-mono);
 }
 
 .version-error {
@@ -235,7 +235,7 @@
 #page-content-wrapper .page-subtitle {
     margin-bottom: 1.5rem;
     color: #ccc;
-    font-size: 1rem;
+    font-size: var(--font-size-md);
 }
 
 /* 6. Responsive Behavior */

--- a/qdashboard/assets/css/theme.css
+++ b/qdashboard/assets/css/theme.css
@@ -41,6 +41,23 @@
     --space-4: 1rem;
     --space-5: 1.5rem;
 
+    /* Typography */
+    --font-family-base: 'IBM Plex Sans', sans-serif;
+    --font-family-mono: 'Courier New', Consolas, monospace;
+
+    /* Font-size scale — every component font-size should reference one of
+       these instead of a hand-picked rem value, so sizes stay consistent
+       across the app. */
+    --font-size-xs:   0.75rem;   /* small: micro/secondary text, badges, counts, code/log */
+    --font-size-sm:   0.8rem;    /* compact UI: buttons, tables, tabs, breadcrumbs */
+    --font-size-base: 0.875rem;  /* default body/component text */
+    --font-size-md:   1rem;      /* card-title, h5, emphasis */
+    --font-size-lg:   1.125rem;  /* h4, modal-title, sidebar heading */
+    --font-size-xl:   1.25rem;   /* h3 */
+    --font-size-2xl:  1.4rem;    /* h2 */
+    --font-size-3xl:  1.5rem;    /* h1 */
+    --font-size-4xl:  1.75rem;   /* large stat/version numbers */
+
     /* Shape */
     --radius: 3px;
     --radius-sm: 2px;
@@ -93,7 +110,7 @@
 
 .vsc-tab {
     padding: var(--space-2) var(--space-3);
-    font-size: 0.8rem;
+    font-size: var(--font-size-sm);
     color: var(--vsc-text-muted);
     background: transparent;
     border: none;
@@ -115,7 +132,7 @@
 /* Compact muted count badge */
 .vsc-badge {
     display: inline-block;
-    font-size: 0.7rem;
+    font-size: var(--font-size-xs);
     line-height: 1.4;
     padding: 0 0.4em;
     border-radius: var(--radius-sm);
@@ -248,13 +265,15 @@ a:hover {
     background: var(--vsc-bg-elevated);
     border-bottom: var(--border-hairline);
     height: 36px;
-    overflow-x: auto;
 }
 
 .qd-tabs-list {
     display: flex;
     flex: 1;
     height: 100%;
+    min-width: 0;
+    overflow-x: auto;
+    overflow-y: hidden;
 }
 
 .qd-tab {
@@ -263,7 +282,7 @@ a:hover {
     gap: .4rem;
     padding: 0 .6rem;
     height: 100%;
-    font-size: .8rem;
+    font-size: var(--font-size-sm);
     color: var(--vsc-text-muted);
     border-right: var(--border-hairline);
     border-bottom: 2px solid transparent;
@@ -298,6 +317,8 @@ a:hover {
     flex-shrink: 0;
 }
 .qd-tab-add-btn:hover { color: var(--vsc-text); background: var(--vsc-bg-hover); }
+
+#qd-tab-add-menu { z-index: 1050; }
 
 .qd-tab-content {
     position: relative;
@@ -340,7 +361,7 @@ a:hover {
     height: 28px;
     background: var(--vsc-accent);
     color: #0a0a0a;
-    font-size: .72rem;
+    font-size: var(--font-size-xs);
     display: flex;
     align-items: center;
     justify-content: space-between;
@@ -363,4 +384,4 @@ a:hover {
 .badge-fit-partial { background: #ffc107; color: #111; }
 .badge-fit-fail  { background: #dc3545; }
 .badge-fit-unknown { background: #6c757d; }
-.history-row { font-size: .8rem; }
+.history-row { font-size: var(--font-size-sm); }

--- a/qdashboard/assets/js/experiment-builder.js
+++ b/qdashboard/assets/js/experiment-builder.js
@@ -1886,9 +1886,9 @@ function makeResizable(handleId, cssVar, storageKey, min, max, widthFromEvent, o
         });
     }
 
-makeResizable('panel-builder-resize-handle', '--panel-builder-width', 'qd_panel_builder_width',
+makeResizable('panel-builder-resize-handle', '--builder-panel-width', 'qd_panel_builder_width',
     180, 600,
     function (e) {
-        var panel = document.getElementById('panel-builder');
+        var panel = document.querySelector('.panel-builder');
         return e.clientX - panel.getBoundingClientRect().left;
     });

--- a/qdashboard/assets/js/settings-panel.js
+++ b/qdashboard/assets/js/settings-panel.js
@@ -1,0 +1,383 @@
+/**
+ * settings-panel.js — Remote execution settings UI
+ *
+ * Manages the Settings tab: load/save RemoteSettings, SSH config
+ * viewer/editor, test connection, and manual sync triggers.
+ */
+
+(function () {
+    'use strict';
+
+    // ------------------------------------------------------------------ //
+    // State                                                                //
+    // ------------------------------------------------------------------ //
+    let _currentSettings = null;
+    let _sshConfigEntries = [];
+
+    // ------------------------------------------------------------------ //
+    // Initialisation                                                       //
+    // ------------------------------------------------------------------ //
+
+    /** Called when the Settings tab pane is first shown. */
+    function initSettingsPanel() {
+        loadSettings();
+        loadSshConfig();
+        pollConnectionStatus();
+
+        $('#btn-save-settings').on('click', saveSettings);
+        $('#btn-reload-settings').on('click', loadSettings);
+        $('#btn-ssh-connect').on('click', connectSSH);
+        $('#btn-ssh-disconnect').on('click', disconnectSSH);
+        $('#btn-save-ssh-config').on('click', saveSshConfig);
+        $('#btn-sync-all').on('click', syncAll);
+        $('#btn-proxy-from-config').on('click', showProxyJumpPicker);
+
+        // Show/hide remote-only cards when execution mode changes
+        $('input[name="executionMode"]').on('change', updateRemoteCardVisibility);
+    }
+
+    // ------------------------------------------------------------------ //
+    // Settings load / save                                                 //
+    // ------------------------------------------------------------------ //
+
+    function loadSettings() {
+        $('#settings-save-result').text('').removeClass('text-success text-danger');
+        fetch('/api/settings/remote')
+            .then(r => r.json())
+            .then(data => {
+                _currentSettings = data;
+                _applySettingsToForm(data);
+                updateRemoteCardVisibility();
+            })
+            .catch(err => console.error('Failed to load settings:', err));
+    }
+
+    function _applySettingsToForm(s) {
+        // Execution mode radio
+        $(`input[name="executionMode"][value="${s.execution_mode || 'local_slurm'}"]`).prop('checked', true);
+
+        // Remote server
+        $('#remote-host').val(s.remote_host || '');
+        $('#remote-port').val(s.remote_port || 22);
+        $('#remote-user').val(s.remote_user || '');
+        $('#remote-root').val(s.remote_root || '~/.qdashboard');
+        $('#remote-environment').val(s.remote_environment || '');
+        $('#remote-platforms-path').val(s.remote_platforms_path || '');
+
+        // SSH auth
+        $('#ssh-key-path').val(s.ssh_key_path || '');
+        $('#use-ssh-agent').prop('checked', s.use_ssh_agent !== false);
+
+        // Proxy
+        $('#proxy-jump').val(s.proxy_jump || '');
+
+        // Sync
+        $('#auto-sync').prop('checked', s.auto_sync !== false);
+        $('#sync-interval').val(s.sync_interval || 30);
+    }
+
+    function _readSettingsFromForm() {
+        return {
+            execution_mode: $('input[name="executionMode"]:checked').val() || 'local_slurm',
+            remote_host: $('#remote-host').val().trim(),
+            remote_port: parseInt($('#remote-port').val()) || 22,
+            remote_user: $('#remote-user').val().trim(),
+            remote_root: $('#remote-root').val().trim() || '~/.qdashboard',
+            remote_environment: $('#remote-environment').val().trim(),
+            remote_platforms_path: $('#remote-platforms-path').val().trim(),
+            ssh_key_path: $('#ssh-key-path').val().trim(),
+            use_ssh_agent: $('#use-ssh-agent').is(':checked'),
+            proxy_jump: $('#proxy-jump').val().trim(),
+            auto_sync: $('#auto-sync').is(':checked'),
+            sync_interval: parseInt($('#sync-interval').val()) || 30,
+        };
+    }
+
+    function saveSettings() {
+        const payload = _readSettingsFromForm();
+        const $result = $('#settings-save-result');
+        $result.text('Saving…').removeClass('text-success text-danger');
+
+        fetch('/api/settings/remote', {
+            method: 'PUT',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify(payload),
+        })
+            .then(r => r.json())
+            .then(data => {
+                _currentSettings = data;
+                $result.text('Saved.').addClass('text-success');
+                setTimeout(() => $result.text(''), 3000);
+            })
+            .catch(err => {
+                $result.text('Save failed: ' + err).addClass('text-danger');
+            });
+    }
+
+    // ------------------------------------------------------------------ //
+    // Card visibility                                                      //
+    // ------------------------------------------------------------------ //
+
+    function updateRemoteCardVisibility() {
+        const mode = $('input[name="executionMode"]:checked').val() || 'local_slurm';
+        const isRemote = mode.startsWith('remote_');
+        $('#settings-remote-server-card, #settings-ssh-auth-card').toggle(isRemote);
+        $('#settings-sync-card').toggle(isRemote);
+    }
+
+    // ------------------------------------------------------------------ //
+    // SSH connection                                                       //
+    // ------------------------------------------------------------------ //
+
+    function connectSSH() {
+        const $badge = $('#settings-conn-badge');
+        $badge.removeClass('badge-success badge-danger badge-warning')
+              .addClass('badge-warning')
+              .html('<i class="fas fa-spinner fa-spin mr-1"></i> Connecting…');
+
+        fetch('/api/remote/connect', { method: 'POST' })
+            .then(r => r.json())
+            .then(data => {
+                if (data.connected) {
+                    $badge.removeClass('badge-secondary badge-warning badge-danger')
+                          .addClass('badge-success')
+                          .html(`<i class="fas fa-circle mr-1"></i> Connected to ${data.host}`);
+                } else {
+                    $badge.removeClass('badge-secondary badge-warning badge-success')
+                          .addClass('badge-danger')
+                          .html(`<i class="fas fa-exclamation-circle mr-1"></i> ${data.message || 'Connection failed'}`);
+                }
+            })
+            .catch(err => {
+                $badge.removeClass('badge-secondary badge-warning badge-success')
+                      .addClass('badge-danger')
+                      .html('<i class="fas fa-exclamation-circle mr-1"></i> Error');
+            });
+    }
+
+    function disconnectSSH() {
+        fetch('/api/remote/disconnect', { method: 'POST' })
+            .then(() => {
+                $('#settings-conn-badge')
+                    .removeClass('badge-success badge-warning badge-danger')
+                    .addClass('badge-secondary')
+                    .html('<i class="fas fa-circle mr-1"></i> Disconnected');
+            });
+    }
+
+    function pollConnectionStatus() {
+        fetch('/api/remote/status')
+            .then(r => r.json())
+            .then(data => {
+                const $badge = $('#settings-conn-badge');
+                if (data.connected) {
+                    $badge.removeClass('badge-secondary badge-warning badge-danger')
+                          .addClass('badge-success')
+                          .html(`<i class="fas fa-circle mr-1"></i> Connected to ${data.host}`);
+
+                    const $syncBadge = $('#settings-sync-status-badge');
+                    if (data.pending_experiments > 0) {
+                        $syncBadge.html(
+                            `<span class="badge badge-warning">${data.pending_experiments} pending sync</span>`
+                        );
+                    } else {
+                        $syncBadge.html('');
+                    }
+                } else {
+                    $badge.removeClass('badge-success badge-warning badge-danger')
+                          .addClass('badge-secondary')
+                          .html('<i class="fas fa-circle mr-1"></i> Disconnected');
+                }
+            })
+            .catch(() => {});
+
+        // Re-poll every 15 s while the tab is active
+        setTimeout(pollConnectionStatus, 15000);
+    }
+
+    // ------------------------------------------------------------------ //
+    // SSH config                                                           //
+    // ------------------------------------------------------------------ //
+
+    function loadSshConfig() {
+        fetch('/api/settings/ssh_config')
+            .then(r => r.json())
+            .then(data => {
+                _sshConfigEntries = data.entries || [];
+                _renderKnownHostsTable(_sshConfigEntries);
+                $('#ssh-config-raw').val(data.raw || '');
+            })
+            .catch(err => {
+                $('#known-hosts-tbody').html(
+                    '<tr><td colspan="6" class="text-danger small">Failed to load SSH config.</td></tr>'
+                );
+            });
+    }
+
+    function _renderKnownHostsTable(entries) {
+        const $tbody = $('#known-hosts-tbody');
+        if (!entries.length) {
+            $tbody.html('<tr><td colspan="6" class="text-center text-muted small">No host entries found in ~/.ssh/config</td></tr>');
+            return;
+        }
+        const rows = entries.map(e => `
+            <tr>
+                <td><code>${_esc(e.alias)}</code></td>
+                <td>${_esc(e.hostname)}</td>
+                <td>${_esc(e.user)}</td>
+                <td>${e.port || 22}</td>
+                <td>${_esc(e.proxy_jump)}</td>
+                <td>
+                    <button class="btn btn-xs btn-outline-primary btn-use-host"
+                            data-alias="${_esc(e.alias)}"
+                            data-hostname="${_esc(e.hostname)}"
+                            data-user="${_esc(e.user)}"
+                            data-port="${e.port || 22}"
+                            data-proxy="${_esc(e.proxy_jump)}"
+                            data-keyfile="${_esc(e.identity_file || '')}"
+                            title="Populate remote server fields">Use</button>
+                </td>
+            </tr>
+        `).join('');
+        $tbody.html(rows);
+
+        // Attach click handlers
+        $tbody.find('.btn-use-host').on('click', function () {
+            const $btn = $(this);
+            $('#remote-host').val($btn.data('hostname') || $btn.data('alias'));
+            $('#remote-port').val($btn.data('port') || 22);
+            $('#remote-user').val($btn.data('user') || '');
+            $('#proxy-jump').val($btn.data('proxy') || '');
+            if ($btn.data('keyfile')) {
+                $('#ssh-key-path').val($btn.data('keyfile'));
+            }
+            // Switch to remote mode if not already
+            const current = $('input[name="executionMode"]:checked').val();
+            if (!current || !current.startsWith('remote_')) {
+                $('#mode-remote-slurm').prop('checked', true).trigger('change');
+            }
+            showNotification('success', `Populated fields from SSH config entry: ${$btn.data('alias')}`);
+        });
+    }
+
+    function saveSshConfig() {
+        const content = $('#ssh-config-raw').val();
+        const $result = $('#ssh-config-save-result');
+        $result.text('Saving…');
+
+        fetch('/api/settings/ssh_config', {
+            method: 'PUT',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ content }),
+        })
+            .then(r => r.json())
+            .then(data => {
+                if (data.success) {
+                    $result.text('Saved. Reloading…');
+                    setTimeout(() => {
+                        loadSshConfig();
+                        $result.text('');
+                    }, 1000);
+                } else {
+                    $result.text('Error: ' + (data.message || 'unknown'));
+                }
+            })
+            .catch(err => $result.text('Save failed.'));
+    }
+
+    function showProxyJumpPicker() {
+        if (!_sshConfigEntries.length) {
+            showNotification('warning', 'No SSH config entries loaded yet.');
+            return;
+        }
+        // Build a simple selection from existing entries that have ProxyJump or could serve as jumps
+        const items = _sshConfigEntries.map(e =>
+            `<button class="btn btn-sm btn-outline-secondary btn-block text-left mb-1 btn-pick-proxy"
+                data-val="${_esc(e.alias)}">${_esc(e.alias)} — ${_esc(e.hostname) || '?'}</button>`
+        ).join('');
+        const html = `
+            <div style="max-height:200px;overflow-y:auto;">
+                ${items}
+            </div>`;
+        // Use a Bootstrap modal if available, otherwise a simple prompt
+        if (typeof $().modal === 'function') {
+            // Create ad-hoc modal
+            const modalId = 'proxy-pick-modal';
+            if (!$('#' + modalId).length) {
+                $('body').append(`
+                    <div class="modal fade" id="${modalId}" tabindex="-1">
+                        <div class="modal-dialog modal-sm">
+                            <div class="modal-content">
+                                <div class="modal-header py-2">
+                                    <h6 class="modal-title">Pick ProxyJump host</h6>
+                                    <button type="button" class="close" data-dismiss="modal">&times;</button>
+                                </div>
+                                <div class="modal-body" id="${modalId}-body"></div>
+                            </div>
+                        </div>
+                    </div>`);
+            }
+            $('#' + modalId + '-body').html(html);
+            $('#' + modalId + '-body .btn-pick-proxy').on('click', function () {
+                $('#proxy-jump').val($(this).data('val'));
+                $('#' + modalId).modal('hide');
+            });
+            $('#' + modalId).modal('show');
+        } else {
+            const choice = prompt('Enter a ProxyJump alias or user@host:');
+            if (choice) $('#proxy-jump').val(choice);
+        }
+    }
+
+    // ------------------------------------------------------------------ //
+    // Data sync                                                            //
+    // ------------------------------------------------------------------ //
+
+    function syncAll() {
+        const $btn = $('#btn-sync-all');
+        const $result = $('#sync-all-result');
+        $btn.prop('disabled', true);
+        $result.text('Syncing…');
+
+        fetch('/api/remote/sync_all', { method: 'POST' })
+            .then(r => r.json())
+            .then(data => {
+                if (data.success) {
+                    $result.text(`Synced ${data.synced} experiment(s). Errors: ${data.errors}`);
+                } else {
+                    $result.text(data.message || 'Sync failed.');
+                }
+            })
+            .catch(err => $result.text('Sync error.'))
+            .finally(() => $btn.prop('disabled', false));
+    }
+
+    // ------------------------------------------------------------------ //
+    // Helpers                                                              //
+    // ------------------------------------------------------------------ //
+
+    function _esc(str) {
+        if (!str) return '';
+        return String(str)
+            .replace(/&/g, '&amp;')
+            .replace(/</g, '&lt;')
+            .replace(/>/g, '&gt;')
+            .replace(/"/g, '&quot;');
+    }
+
+    /** Show a Bootstrap notification card (reuses the global helper if present). */
+    function showNotification(type, msg) {
+        if (typeof window.showNotification === 'function') {
+            window.showNotification(type, msg);
+        } else {
+            console.info('[Settings]', type, msg);
+        }
+    }
+
+    // ------------------------------------------------------------------ //
+    // Public API (attached to window so shell.js can call initSettingsPanel)
+    // ------------------------------------------------------------------ //
+    window.initSettingsPanel = initSettingsPanel;
+    window.loadSettings = loadSettings;
+
+})();

--- a/qdashboard/assets/js/shell.js
+++ b/qdashboard/assets/js/shell.js
@@ -11,7 +11,8 @@
     var TAB_DEFS = {
         slurm:          { label: 'Slurm Monitor',     icon: 'fa-tasks' },
         qpu_status:     { label: 'QPU Status',        icon: 'fa-microchip' },
-        action_builder: { label: 'Action Card Builder', icon: 'fa-flask' }
+        action_builder: { label: 'Action Card Builder', icon: 'fa-flask' },
+        settings:       { label: 'Settings',          icon: 'fa-cog' }
     };
 
     var TABS_KEY = 'qd_shell_tabs';
@@ -23,6 +24,9 @@
         slurm: {
             onOpen: function () { if (window.initializeDashboardCommon) window.initializeDashboardCommon(); },
             onClose: function () { if (window.stopAutoRefresh) window.stopAutoRefresh(); }
+        },
+        settings: {
+            onOpen: function () { if (window.initSettingsPanel) window.initSettingsPanel(); }
         }
     };
 

--- a/qdashboard/core/app.py
+++ b/qdashboard/core/app.py
@@ -14,6 +14,7 @@ from fastapi.templating import Jinja2Templates
 from ..utils.formatters import size_fmt, time_desc, data_fmt, icon_fmt, time_humanize
 from qdashboard.utils.logger import get_logger
 from .config import DEFAULT_PORT, DEFAULT_HOST, DEFAULT_QD_ROOT, set_config
+from ..remote.connection import SSHConnectionManager
 
 
 logger = get_logger(__name__)
@@ -123,6 +124,9 @@ def create_app(config: dict = None) -> FastAPI:
     # Store config in app state for access via request.app.state.config
     app.state.config = config or {}
 
+    # Attach the SSH connection manager (used in remote execution mode)
+    app.state.ssh_manager = SSHConnectionManager()
+
     # Startup: initialise experiment history DB in a thread-pool executor
     # so it does not block the event loop. Errors are non-fatal.
     @app.on_event("startup")
@@ -135,6 +139,20 @@ def create_app(config: dict = None) -> FastAPI:
             await loop.run_in_executor(None, _init_db, _cfg)
         except Exception as _exc:
             logger.warning(f"DB init failed (non-fatal): {_exc}")
+
+    @app.on_event("startup")
+    async def _startup_background_sync():
+        """Start the background experiment-sync loop when remote + auto_sync is on."""
+        import asyncio
+        asyncio.ensure_future(_background_sync_loop(app))
+
+    @app.on_event("shutdown")
+    async def _shutdown_ssh():
+        """Disconnect the SSH manager cleanly on server shutdown."""
+        try:
+            await app.state.ssh_manager.disconnect()
+        except Exception:
+            pass
 
     # Mount static files at /assets
     app.mount("/assets", StaticFiles(directory=assets_dir), name="assets")
@@ -236,3 +254,98 @@ def get_config():
     """Get application configuration from environment variables."""
     from .config import get_config as _get_config
     return _get_config()
+
+
+async def _background_sync_loop(app) -> None:
+    """Periodically poll remote SLURM and sync completed experiments to local storage.
+
+    Runs as a fire-and-forget asyncio task for the lifetime of the server.
+    Only active when execution_mode is ``remote_*`` and ``auto_sync`` is True.
+    Errors are caught and logged; the loop always continues.
+    """
+    import asyncio
+
+    while True:
+        try:
+            from .config import get_remote_settings, get_qd_root, get_data_dir
+            settings = get_remote_settings()
+
+            if not settings.is_remote() or not settings.auto_sync:
+                await asyncio.sleep(settings.sync_interval or 30)
+                continue
+
+            ssh_manager = app.state.ssh_manager
+            if not ssh_manager.is_connected():
+                await asyncio.sleep(settings.sync_interval)
+                continue
+
+            # Query local DB for pending/running remote experiments
+            try:
+                from ..db.database import get_db_connection, query_runs
+                config = app.state.config
+                data_dir = config.get('data_dir') or get_data_dir()
+
+                with get_db_connection(config) as conn:
+                    pending = query_runs(
+                        conn,
+                        status=['pending', 'running'],
+                        limit=100,
+                    )
+
+                for exp in pending:
+                    job_id = exp.get('slurm_job_id')
+                    experiment_id = exp.get('experiment_id')
+                    if not job_id or not experiment_id:
+                        continue
+
+                    # Check SLURM state on remote
+                    from ..remote.executor import RemoteSlurmClient, RemoteExecutor
+                    slurm = RemoteSlurmClient(RemoteExecutor(ssh_manager))
+                    state = await slurm.check_job_status(job_id)
+
+                    if state in RemoteSlurmClient.ACTIVE_STATES:
+                        continue  # still running
+
+                    # Job finished — resolve platform/date from experiment_id
+                    platform = exp.get('platform') or exp.get('qpu_name', '')
+                    # experiment_id format: YYYYMMDD-<hex>
+                    date_str = experiment_id.split('-')[0] if '-' in experiment_id else ''
+
+                    if not platform or not date_str:
+                        continue
+
+                    from ..remote.file_sync import sync_experiment_from_remote
+                    files = await sync_experiment_from_remote(
+                        experiment_id, platform, date_str,
+                        settings, ssh_manager, data_dir,
+                    )
+
+                    if files:
+                        # Update DB status
+                        output_meta = __import__('os').path.join(
+                            data_dir, platform, date_str, experiment_id, 'output', 'meta.json'
+                        )
+                        new_status = 'completed' if __import__('os').path.exists(output_meta) else 'failed'
+                        with get_db_connection(config) as conn:
+                            from ..db.database import upsert_experiment_run
+                            upsert_experiment_run(conn, {
+                                'experiment_id': experiment_id,
+                                'status': new_status,
+                                'report_available': new_status == 'completed',
+                            })
+                        logger.info(
+                            "Auto-sync: %s → %s (%d files)",
+                            experiment_id, new_status, len(files),
+                        )
+            except Exception as _inner:
+                logger.debug("Background sync inner error (non-fatal): %s", _inner)
+
+        except Exception as _outer:
+            logger.debug("Background sync outer error (non-fatal): %s", _outer)
+
+        try:
+            from .config import get_remote_settings as _gs
+            interval = _gs().sync_interval or 30
+        except Exception:
+            interval = 30
+        await asyncio.sleep(interval)

--- a/qdashboard/core/app.py
+++ b/qdashboard/core/app.py
@@ -279,6 +279,16 @@ async def _background_sync_loop(app) -> None:
                 await asyncio.sleep(settings.sync_interval)
                 continue
 
+            # Keep the local read-only platforms mirror in sync with the
+            # remote qibolab_platforms_qrc directory (QPU monitoring,
+            # topology, and partition lookups all read from this mirror).
+            try:
+                from ..remote.platforms_git import sync_platforms_mirror
+                mirror_dir = os.path.join(get_qd_root(), 'platforms_mirror')
+                await sync_platforms_mirror(settings, ssh_manager, mirror_dir)
+            except Exception as _mirror_err:
+                logger.debug("Background platforms mirror sync error (non-fatal): %s", _mirror_err)
+
             # Query local DB for pending/running remote experiments
             try:
                 from ..db.database import get_db_connection, query_runs

--- a/qdashboard/core/config.py
+++ b/qdashboard/core/config.py
@@ -114,6 +114,17 @@ def get_environment() -> Optional[str]:
     return get_config_value('environment')
 
 
+def get_remote_settings_path() -> str:
+    """Return the path to the remote settings JSON file."""
+    return os.path.join(get_qd_root(), 'remote_settings.json')
+
+
+def get_remote_settings():
+    """Load and return the current RemoteSettings object."""
+    from ..remote.settings import load_remote_settings
+    return load_remote_settings(get_qd_root())
+
+
 def ensure_directory_exists(directory_path: str) -> str:
     """
     Ensure a directory exists, creating it if necessary.

--- a/qdashboard/db/database.py
+++ b/qdashboard/db/database.py
@@ -16,7 +16,7 @@ import json
 import os
 import sqlite3
 import time
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, List, Optional, Union
 
 from qdashboard.utils.logger import get_logger
 
@@ -183,7 +183,7 @@ def upsert_experiment_run(conn: sqlite3.Connection, data: Dict[str, Any]) -> Non
 # Queries                                                             #
 # ------------------------------------------------------------------ #
 
-def _build_where(platform: str, protocol: str, status: str,
+def _build_where(platform: str, protocol: str, status: Union[str, List[str]],
                  fit: str, date_from: str, date_to: str):
     clauses, params = [], []
     if platform:
@@ -193,8 +193,13 @@ def _build_where(platform: str, protocol: str, status: str,
         clauses.append("r.protocol_id = ?")
         params.append(protocol)
     if status:
-        clauses.append("r.status = ?")
-        params.append(status)
+        if isinstance(status, (list, tuple, set)):
+            statuses = list(status)
+            clauses.append(f"r.status IN ({','.join('?' * len(statuses))})")
+            params.extend(statuses)
+        else:
+            clauses.append("r.status = ?")
+            params.append(status)
     if fit == "pass":
         clauses.append("r.overall_fit_success = 1")
     elif fit == "fail":
@@ -232,7 +237,7 @@ def query_runs(
     conn: sqlite3.Connection,
     platform: str = "",
     protocol: str = "",
-    status: str = "",
+    status: Union[str, List[str]] = "",
     fit: str = "",
     date_from: str = "",
     date_to: str = "",
@@ -249,7 +254,7 @@ def count_runs(
     conn: sqlite3.Connection,
     platform: str = "",
     protocol: str = "",
-    status: str = "",
+    status: Union[str, List[str]] = "",
     fit: str = "",
     date_from: str = "",
     date_to: str = "",

--- a/qdashboard/experiments/job_submission.py
+++ b/qdashboard/experiments/job_submission.py
@@ -947,11 +947,8 @@ async def submit_experiment_remote(
         # 5. Determine SLURM partition and remote platforms path              #
         # ------------------------------------------------------------------ #
         partition = runcard_data.get('partition') or get_partition(platform) or 'default'
-        remote_platforms_base = (
-            _rexpand(settings.remote_platforms_path)
-            if settings.remote_platforms_path
-            else (get_platforms_path(config.get('root', '')) or '')
-        )
+        from ..remote.platforms_git import resolve_remote_platforms_path
+        remote_platforms_base = await resolve_remote_platforms_path(settings, ssh_manager)
 
         # ------------------------------------------------------------------ #
         # 6. Submit via sbatch or direct exec                                 #

--- a/qdashboard/experiments/job_submission.py
+++ b/qdashboard/experiments/job_submission.py
@@ -798,3 +798,404 @@ def find_latest_experiment(
 
     return None
 
+
+# =========================================================================== #
+# Remote submission (remote_slurm / remote_direct modes)                      #
+# =========================================================================== #
+
+def _build_remote_slurm_script(
+    experiment_id: str,
+    remote_exp_dir: str,
+    remote_runcard_path: str,
+    platform: str,
+    partition: str,
+    remote_platforms_base: str,
+    environment: str = None,
+    auto_update: bool = True,
+) -> str:
+    """Return the text of a SLURM batch script for execution on the remote host."""
+    remote_output_dir = f"{remote_exp_dir}/output"
+    remote_logs_dir = f"{remote_exp_dir}/logs"
+    activate_line = (
+        f"source {environment}/bin/activate" if environment else "# No environment specified"
+    )
+
+    return f"""#!/bin/bash
+#SBATCH --job-name={experiment_id}
+#SBATCH --partition={partition}
+#SBATCH --output={remote_logs_dir}/slurm_output.log
+#SBATCH --time=01:00:00
+
+export QIBOLAB_PLATFORMS={remote_platforms_base}
+export QIBO_PLATFORM={platform}
+
+mkdir -p {remote_output_dir} {remote_logs_dir}
+
+echo "Job ID: $SLURM_JOB_ID"
+echo "Experiment ID: {experiment_id}"
+echo "Platform: {platform}"
+echo "Start time: $(date)"
+
+cd {remote_exp_dir}
+
+{activate_line}
+
+echo "Running experiment..."
+qq run {remote_runcard_path} -o {remote_output_dir} -f{'' if auto_update else ' --no-update'}
+
+echo "End time: $(date)"
+echo "Exit code: $?"
+exit 0
+"""
+
+
+async def submit_experiment_remote(
+    runcard_data: Dict[str, Any],
+    config: Dict[str, Any],
+    settings,
+    ssh_manager,
+    environment: str = None,
+    auto_update: bool = True,
+) -> Dict[str, Any]:
+    """Submit an experiment to a remote host via SSH.
+
+    Supports both ``remote_slurm`` (sbatch) and ``remote_direct`` (qq run via
+    nohup) execution modes as indicated by *settings*.
+
+    The experiment directory is created both locally (for tracking and future
+    sync target) and on the remote (for actual execution).  The runcard is
+    uploaded via SFTP before submission.
+
+    Returns the same dict shape as :func:`submit_experiment`.
+    """
+    try:
+        if 'platform' not in runcard_data:
+            return {'success': False, 'message': 'Missing required field: platform'}
+
+        if not ssh_manager.is_connected():
+            return {
+                'success': False,
+                'message': 'Not connected to remote host.  Open Settings → Remote and click Connect.',
+            }
+
+        platform = runcard_data['platform']
+        effective_env = (
+            environment
+            or runcard_data.get('environment')
+            or settings.remote_environment
+            or None
+        )
+
+        # ------------------------------------------------------------------ #
+        # 1. Create local experiment directory (tracking + sync target)       #
+        # ------------------------------------------------------------------ #
+        ensure_directory_exists(config.get('data_dir', os.path.join(config['qd_root'], 'data')))
+        temp_dir = config.get('temp_dir') or get_temp_dir()
+        temp_runcard = create_temp_runcard_from_data(runcard_data, temp_dir)
+        try:
+            experiment_id = generate_experiment_id(temp_runcard, platform)
+        finally:
+            try:
+                os.unlink(temp_runcard)
+            except OSError:
+                pass
+
+        local_exp_dir = create_experiment_directory(experiment_id, platform, config)
+        local_runcard_path, _ = prepare_runcard_from_data(runcard_data, local_exp_dir)
+        date_str = experiment_id.split('-')[0]
+
+        # ------------------------------------------------------------------ #
+        # 2. Resolve remote home and build remote paths                       #
+        # ------------------------------------------------------------------ #
+        from ..remote.file_sync import _resolve_remote_home
+        remote_home = await _resolve_remote_home(ssh_manager)
+
+        def _rexpand(path: str) -> str:
+            return path.replace('~', remote_home, 1) if remote_home and path.startswith('~') else path
+
+        remote_root = _rexpand(settings.remote_root)
+        remote_exp_dir = f"{remote_root}/{platform}/{date_str}/{experiment_id}"
+        remote_runcard = f"{remote_exp_dir}/runcard.yml"
+        remote_script = f"{remote_exp_dir}/job_script.sh"
+
+        # ------------------------------------------------------------------ #
+        # 3. Create remote directories                                        #
+        # ------------------------------------------------------------------ #
+        _, _, rc = await ssh_manager.run(
+            f"mkdir -p {remote_exp_dir}/output {remote_exp_dir}/logs",
+            timeout=15,
+        )
+        if rc != 0:
+            return {
+                'success': False,
+                'message': f'Failed to create remote directory: {remote_exp_dir}',
+            }
+
+        # ------------------------------------------------------------------ #
+        # 4. Upload runcard via SFTP                                          #
+        # ------------------------------------------------------------------ #
+        from ..remote.file_sync import sftp_upload_file, sftp_upload_text
+        try:
+            await sftp_upload_file(local_runcard_path, remote_runcard, ssh_manager)
+        except Exception as _upload_err:
+            return {
+                'success': False,
+                'message': f'Failed to upload runcard to remote: {_upload_err}',
+            }
+
+        # ------------------------------------------------------------------ #
+        # 5. Determine SLURM partition and remote platforms path              #
+        # ------------------------------------------------------------------ #
+        partition = runcard_data.get('partition') or get_partition(platform) or 'default'
+        remote_platforms_base = (
+            _rexpand(settings.remote_platforms_path)
+            if settings.remote_platforms_path
+            else (get_platforms_path(config.get('root', '')) or '')
+        )
+
+        # ------------------------------------------------------------------ #
+        # 6. Submit via sbatch or direct exec                                 #
+        # ------------------------------------------------------------------ #
+        job_id: Optional[str] = None
+        execution_note = ''
+
+        if settings.uses_slurm():
+            script_content = _build_remote_slurm_script(
+                experiment_id, remote_exp_dir, remote_runcard,
+                platform, partition, remote_platforms_base,
+                effective_env, auto_update,
+            )
+            try:
+                await sftp_upload_text(script_content, remote_script, ssh_manager)
+            except Exception as _script_err:
+                return {
+                    'success': False,
+                    'message': f'Failed to upload job script to remote: {_script_err}',
+                }
+            await ssh_manager.run(f"chmod +x {remote_script}", timeout=10)
+            stdout, stderr, rc = await ssh_manager.run(f"sbatch {remote_script}", timeout=30)
+            if rc != 0:
+                return {'success': False, 'message': f'sbatch failed: {stderr.strip()}'}
+            for line in stdout.splitlines():
+                if 'Submitted batch job' in line:
+                    job_id = line.split()[-1]
+                    break
+            execution_note = f'SLURM job {job_id} on {settings.remote_host}'
+            logger.info('Remote SLURM job: %s → job_id=%s', experiment_id, job_id)
+
+        else:
+            # remote_direct — launch qq run detached via nohup
+            if effective_env:
+                env_activate = f"source {effective_env}/bin/activate && "
+            else:
+                env_activate = ''
+            remote_output_dir = f"{remote_exp_dir}/output"
+            remote_log = f"{remote_exp_dir}/logs/slurm_output.log"
+            no_upd = '' if auto_update else ' --no-update'
+            direct_cmd = (
+                f"nohup bash -c '"
+                f"export QIBOLAB_PLATFORMS={remote_platforms_base}; "
+                f"{env_activate}"
+                f"qq run {remote_runcard} -o {remote_output_dir} -f{no_upd}"
+                f"' >> {remote_log} 2>&1 & echo $!"
+            )
+            stdout, stderr, rc = await ssh_manager.run(direct_cmd, timeout=30)
+            if rc != 0:
+                return {'success': False, 'message': f'Remote direct exec failed: {stderr.strip()}'}
+            pid = stdout.strip()
+            job_id = f"pid_{pid}"
+            execution_note = f'Direct exec PID {pid} on {settings.remote_host}'
+            logger.info('Remote direct exec: %s → PID %s', experiment_id, pid)
+
+        # ------------------------------------------------------------------ #
+        # 7. Save local metadata                                              #
+        # ------------------------------------------------------------------ #
+        metadata = {
+            'experiment_id': experiment_id,
+            'job_id': job_id,
+            'platform': platform,
+            'partition': partition,
+            'environment': effective_env,
+            'submitted_at': time.time(),
+            'experiment_dir': local_exp_dir,
+            'output_dir': os.path.join(local_exp_dir, 'output'),
+            'runcard_path': local_runcard_path,
+            'remote_exp_dir': remote_exp_dir,
+            'remote_host': settings.remote_host,
+            'execution_mode': settings.execution_mode,
+            'type': 'new_experiment',
+            'source': 'runcard_data',
+            'note': execution_note,
+        }
+        save_experiment_metadata(local_exp_dir, metadata)
+
+        # ------------------------------------------------------------------ #
+        # 8. Write to local DB                                                #
+        # ------------------------------------------------------------------ #
+        try:
+            from ..db.database import (
+                get_db_connection, get_or_create_qpu, upsert_experiment_run,
+                add_qpu_qubits, _extract_protocol_info,
+            )
+            with get_db_connection(config) as conn:
+                qpu_id = get_or_create_qpu(conn, platform)
+                proto_id, proto_name, qubit_list = _extract_protocol_info(runcard_data)
+                if qubit_list:
+                    add_qpu_qubits(conn, qpu_id, qubit_list)
+                upsert_experiment_run(conn, {
+                    'experiment_id': experiment_id,
+                    'qpu_id': qpu_id,
+                    'protocol_id': proto_id,
+                    'protocol_name': proto_name,
+                    'target_qubits': qubit_list,
+                    'submitted_at': metadata['submitted_at'],
+                    'slurm_job_id': job_id,
+                    'status': 'pending',
+                    'runcard_path': local_runcard_path,
+                    'output_dir': metadata['output_dir'],
+                })
+        except Exception as _db_exc:
+            logger.warning('Remote submit DB write failed (non-fatal): %s', _db_exc)
+
+        return {
+            'success': True,
+            'message': f'Experiment submitted: {execution_note}',
+            'experiment_id': experiment_id,
+            'job_id': job_id,
+            'experiment_dir': local_exp_dir,
+            'output_dir': metadata['output_dir'],
+            'metadata': metadata,
+        }
+
+    except Exception as exc:
+        logger.exception('submit_experiment_remote error')
+        return {'success': False, 'message': f'Remote submission error: {exc}'}
+
+
+# =========================================================================== #
+# Local direct submission (local_direct mode)                                 #
+# =========================================================================== #
+
+def submit_experiment_direct(
+    runcard_data: Dict[str, Any],
+    config: Dict[str, Any],
+    environment: str = None,
+    auto_update: bool = True,
+) -> Dict[str, Any]:
+    """Submit an experiment directly (no SLURM) on the local machine.
+
+    Launches ``qq run`` as a background process with ``start_new_session=True``
+    so it survives if the dashboard restarts.  The PID is stored as the
+    pseudo job-ID (prefixed ``local_``).
+
+    Returns the same dict shape as :func:`submit_experiment`.
+    """
+    try:
+        if 'platform' not in runcard_data:
+            return {'success': False, 'message': 'Missing required field: platform'}
+
+        platform = runcard_data['platform']
+        effective_env = environment or runcard_data.get('environment') or config.get('environment')
+
+        ensure_directory_exists(config.get('data_dir', os.path.join(config['qd_root'], 'data')))
+        temp_dir = config.get('temp_dir') or get_temp_dir()
+        temp_runcard = create_temp_runcard_from_data(runcard_data, temp_dir)
+        try:
+            experiment_id = generate_experiment_id(temp_runcard, platform)
+        finally:
+            try:
+                os.unlink(temp_runcard)
+            except OSError:
+                pass
+
+        local_exp_dir = create_experiment_directory(experiment_id, platform, config)
+        local_runcard_path, _ = prepare_runcard_from_data(runcard_data, local_exp_dir)
+        output_dir = os.path.join(local_exp_dir, 'output')
+        logs_dir = os.path.join(local_exp_dir, 'logs')
+        ensure_directory_exists(output_dir)
+        ensure_directory_exists(logs_dir)
+        log_file = os.path.join(logs_dir, 'slurm_output.log')
+
+        platforms_base = get_platforms_path(config.get('root', '')) or ''
+
+        cmd_parts = ['qq', 'run', local_runcard_path, '-o', output_dir, '-f']
+        if not auto_update:
+            cmd_parts.append('--no-update')
+
+        env_vars = os.environ.copy()
+        if platforms_base:
+            env_vars['QIBOLAB_PLATFORMS'] = platforms_base
+        env_vars['QIBO_PLATFORM'] = platform
+
+        # If a venv/conda environment is specified, wrap in a bash source
+        if effective_env:
+            activate = os.path.join(os.path.expanduser(effective_env), 'bin', 'activate')
+            if os.path.exists(activate):
+                cmd_parts = ['bash', '-c', f"source {activate} && " + ' '.join(cmd_parts)]
+
+        with open(log_file, 'w') as log_fh:
+            proc = subprocess.Popen(
+                cmd_parts,
+                stdout=log_fh,
+                stderr=subprocess.STDOUT,
+                env=env_vars,
+                start_new_session=True,
+            )
+
+        job_id = f"local_{proc.pid}"
+        metadata = {
+            'experiment_id': experiment_id,
+            'job_id': job_id,
+            'platform': platform,
+            'environment': effective_env,
+            'submitted_at': time.time(),
+            'experiment_dir': local_exp_dir,
+            'output_dir': output_dir,
+            'runcard_path': local_runcard_path,
+            'execution_mode': 'local_direct',
+            'type': 'new_experiment',
+            'source': 'runcard_data',
+        }
+        save_experiment_metadata(local_exp_dir, metadata)
+
+        try:
+            from ..db.database import (
+                get_db_connection, get_or_create_qpu, upsert_experiment_run,
+                add_qpu_qubits, _extract_protocol_info,
+            )
+            with get_db_connection(config) as conn:
+                qpu_id = get_or_create_qpu(conn, platform)
+                proto_id, proto_name, qubit_list = _extract_protocol_info(runcard_data)
+                if qubit_list:
+                    add_qpu_qubits(conn, qpu_id, qubit_list)
+                upsert_experiment_run(conn, {
+                    'experiment_id': experiment_id,
+                    'qpu_id': qpu_id,
+                    'protocol_id': proto_id,
+                    'protocol_name': proto_name,
+                    'target_qubits': qubit_list,
+                    'submitted_at': metadata['submitted_at'],
+                    'slurm_job_id': job_id,
+                    'status': 'running',
+                    'runcard_path': local_runcard_path,
+                    'output_dir': output_dir,
+                })
+        except Exception as _db_exc:
+            logger.warning('Direct submit DB write failed (non-fatal): %s', _db_exc)
+
+        logger.info('Local direct experiment started: %s (PID %s)', experiment_id, proc.pid)
+        return {
+            'success': True,
+            'message': f'Experiment started locally (PID {proc.pid})',
+            'experiment_id': experiment_id,
+            'job_id': job_id,
+            'experiment_dir': local_exp_dir,
+            'output_dir': output_dir,
+            'metadata': metadata,
+        }
+
+    except Exception as exc:
+        logger.exception('submit_experiment_direct error')
+        return {'success': False, 'message': f'Direct submission error: {exc}'}
+
+

--- a/qdashboard/qpu/__init__.py
+++ b/qdashboard/qpu/__init__.py
@@ -9,9 +9,8 @@ from .platforms import (
     get_current_branch_info
 )
 from .monitoring import (
-    get_qpu_health, 
-    get_available_qpus, 
-    get_qibo_versions,  
+    get_available_qpus,
+    get_qibo_versions,
 )
 
 from .utils import (
@@ -26,7 +25,6 @@ __all__ = [
     'list_repository_branches',
     'switch_repository_branch',
     'get_current_branch_info',
-    'get_qpu_health',
     'get_available_qpus',
     'get_qibo_versions',
     'detect_and_save_qibolab_version', 

--- a/qdashboard/qpu/monitoring.py
+++ b/qdashboard/qpu/monitoring.py
@@ -26,12 +26,6 @@ except ImportError:
 
 logger = get_logger(__name__)
 
-def get_qpu_health():
-    """Get overall QPU health status."""
-    # Placeholder for now - could be expanded to check multiple health metrics
-    return "N/A"
-
-
 def check_qpu_queue_status(qpu_name, queue_name):
     """
     Check if a QPU is online based on SLURM queue status.

--- a/qdashboard/qpu/monitoring.py
+++ b/qdashboard/qpu/monitoring.py
@@ -137,7 +137,7 @@ def get_qpu_queue_mapping(qrc_path):
 
 def get_available_qpus():
     """Get count of available QPUs from the platforms directory."""
-    root = os.path.normpath(os.environ.get('HOME'))
+    root = os.path.normpath(os.environ.get('HOME') or os.path.expanduser('~'))
     qrc_path = get_platforms_path(root)
     
     # Check if platforms directory exists
@@ -261,7 +261,7 @@ def get_qpu_list():
     Only directories committed to the repository's current HEAD are considered, so
     untracked or uncommitted directories (e.g. created via the file browser) are excluded.
     """
-    root = os.path.normpath(os.environ.get('HOME'))
+    root = os.path.normpath(os.environ.get('HOME') or os.path.expanduser('~'))
     qrc_path = get_platforms_path(root)
     qpus = []
 
@@ -509,7 +509,7 @@ def __get_parameters(platform) -> dict:
 def get_qpu_details():
     """Get detailed information about all available QPUs."""
     
-    root = os.path.normpath(os.environ.get('HOME'))
+    root = os.path.normpath(os.environ.get('HOME') or os.path.expanduser('~'))
     platforms_path = get_platforms_path(root)
     qpus_list = []
     qpu_names = get_qpu_list()

--- a/qdashboard/qpu/platforms.py
+++ b/qdashboard/qpu/platforms.py
@@ -154,17 +154,34 @@ def update_platforms_repository(platforms_path):
 def get_platforms_path(root_path=None):
     """
     Get the path to the qibolab platforms directory.
-    
-    This is a convenience function that calls ensure_platforms_directory()
-    and handles some errors.
-    
+
+    When the current execution mode is ``remote_*``, this returns the local
+    read-only mirror of the remote host's platforms directory instead of the
+    local ``QIBOLAB_PLATFORMS`` clone — the mirror is kept in sync by
+    :func:`qdashboard.remote.platforms_git.sync_platforms_mirror` and is what
+    every reader (QPU monitoring, topology, partition lookup) should see while
+    connected to a remote host, since git operations only ever run there.
+
+    Otherwise, this is a convenience function that calls
+    ensure_platforms_directory() and handles some errors.
+
     Args:
         root_path (str, optional): Root directory where to create platforms dir.
                                  Defaults to user home directory.
-    
+
     Returns:
         str: Path to platforms directory, or None if unable to ensure it exists
     """
+    try:
+        from ..core.config import get_qd_root, get_remote_settings
+        settings = get_remote_settings()
+        if settings.is_remote():
+            mirror_dir = os.path.join(get_qd_root(), 'platforms_mirror')
+            os.makedirs(mirror_dir, exist_ok=True)
+            return mirror_dir
+    except Exception as e:
+        logger.debug(f"Could not check remote settings for platforms path: {e}")
+
     try:
         return ensure_platforms_directory(root_path)
     except Exception as e:

--- a/qdashboard/remote/__init__.py
+++ b/qdashboard/remote/__init__.py
@@ -1,0 +1,18 @@
+"""
+Remote execution support for QDashboard.
+
+This package provides SSH-based remote execution, data synchronisation, and
+settings persistence so the dashboard can run locally while submitting jobs to
+a remote SLURM cluster.
+"""
+
+from .settings import RemoteSettings, load_remote_settings, save_remote_settings
+from .connection import SSHConnectionManager, SSHConnectionError
+
+__all__ = [
+    "RemoteSettings",
+    "load_remote_settings",
+    "save_remote_settings",
+    "SSHConnectionManager",
+    "SSHConnectionError",
+]

--- a/qdashboard/remote/connection.py
+++ b/qdashboard/remote/connection.py
@@ -1,0 +1,280 @@
+"""
+SSH connection manager for remote execution mode.
+
+Uses ``asyncssh`` (if installed) for async-native SSH connectivity that fits
+naturally into FastAPI's event loop.  The manager is attached to
+``app.state.ssh_manager`` at startup and shared across all request handlers.
+
+Usage::
+
+    # In a route handler
+    manager = request.app.state.ssh_manager
+    await manager.connect(settings)
+    stdout, stderr, rc = await manager.run("squeue --noheader")
+"""
+
+import asyncio
+import os
+import time
+from typing import Optional, Tuple
+
+from ..utils.logger import get_logger
+
+logger = get_logger(__name__)
+
+
+# --------------------------------------------------------------------------- #
+# Custom exception                                                             #
+# --------------------------------------------------------------------------- #
+
+class SSHConnectionError(Exception):
+    """Raised when an SSH operation cannot be completed."""
+
+
+# --------------------------------------------------------------------------- #
+# Optional asyncssh import                                                     #
+# --------------------------------------------------------------------------- #
+
+try:
+    import asyncssh  # type: ignore[import]
+    _ASYNCSSH_AVAILABLE = True
+except ImportError:
+    _ASYNCSSH_AVAILABLE = False
+
+
+# --------------------------------------------------------------------------- #
+# Connection manager                                                           #
+# --------------------------------------------------------------------------- #
+
+class SSHConnectionManager:
+    """
+    Persistent asyncssh SSH connection, shared across request handlers.
+
+    Thread-safety: The underlying :class:`asyncio.Lock` ensures that only one
+    coroutine opens or closes the connection at a time.  ``run()`` and
+    ``get_sftp()`` can be called concurrently once connected.
+    """
+
+    def __init__(self) -> None:
+        self._connection: Optional["asyncssh.SSHClientConnection"] = None  # type: ignore[name-defined]
+        self._jump_connection: Optional["asyncssh.SSHClientConnection"] = None  # type: ignore[name-defined]
+        self._settings = None          # RemoteSettings stored at connect time
+        self._connected_at: Optional[float] = None
+        self._is_connected: bool = False
+        self._lock: asyncio.Lock = asyncio.Lock()
+
+    # ------------------------------------------------------------------ #
+    # Public API                                                           #
+    # ------------------------------------------------------------------ #
+
+    @property
+    def asyncssh_available(self) -> bool:
+        return _ASYNCSSH_AVAILABLE
+
+    def is_connected(self) -> bool:
+        """Return True when an active SSH connection is held."""
+        return self._is_connected and self._connection is not None
+
+    async def connect(self, settings) -> None:
+        """Open (or re-open) an SSH connection using *settings*.
+
+        Args:
+            settings: :class:`~qdashboard.remote.settings.RemoteSettings` instance.
+
+        Raises:
+            :class:`SSHConnectionError`: If the connection cannot be established.
+        """
+        if not _ASYNCSSH_AVAILABLE:
+            raise SSHConnectionError(
+                "asyncssh is not installed.  Run: pip install 'asyncssh>=2.14'"
+            )
+
+        async with self._lock:
+            await self._close_connections()
+
+            auth_kwargs: dict = {}
+            if settings.ssh_key_path:
+                key_path = os.path.expanduser(settings.ssh_key_path)
+                if not os.path.exists(key_path):
+                    raise SSHConnectionError(
+                        f"SSH key file not found: {key_path}"
+                    )
+                auth_kwargs["client_keys"] = [key_path]
+            if settings.use_ssh_agent:
+                # asyncssh uses the system agent automatically when
+                # client_keys is not set, or alongside it.
+                auth_kwargs.setdefault("agent_path", None)  # use default agent socket
+
+            conn_kwargs: dict = {
+                "host": settings.remote_host,
+                "port": settings.remote_port,
+                "username": settings.remote_user,
+                "known_hosts": None,  # TODO: use known_hosts for production
+                **auth_kwargs,
+            }
+
+            # ProxyJump: first open a tunnel connection, then use it
+            if settings.proxy_jump:
+                try:
+                    jump_host, jump_port, jump_user = _parse_jump_target(
+                        settings.proxy_jump, settings.remote_user
+                    )
+                    self._jump_connection = await asyncssh.connect(
+                        jump_host,
+                        port=jump_port,
+                        username=jump_user,
+                        known_hosts=None,
+                        **auth_kwargs,
+                    )
+                    conn_kwargs["tunnel"] = self._jump_connection
+                    logger.debug(
+                        "ProxyJump tunnel opened via %s@%s:%d",
+                        jump_user, jump_host, jump_port,
+                    )
+                except Exception as exc:
+                    raise SSHConnectionError(
+                        f"ProxyJump to '{settings.proxy_jump}' failed: {exc}"
+                    ) from exc
+
+            try:
+                self._connection = await asyncssh.connect(**conn_kwargs)
+                self._settings = settings
+                self._connected_at = time.time()
+                self._is_connected = True
+                logger.info(
+                    "SSH connected to %s@%s:%d",
+                    settings.remote_user,
+                    settings.remote_host,
+                    settings.remote_port,
+                )
+            except asyncssh.DisconnectError as exc:
+                raise SSHConnectionError(f"Connection refused: {exc}") from exc
+            except asyncssh.PermissionDenied as exc:
+                raise SSHConnectionError(f"Authentication failed: {exc}") from exc
+            except Exception as exc:
+                raise SSHConnectionError(f"Connection failed: {exc}") from exc
+
+    async def disconnect(self) -> None:
+        """Close the SSH connection gracefully."""
+        async with self._lock:
+            await self._close_connections()
+            logger.info("SSH connection closed")
+
+    async def run(
+        self, cmd: str, timeout: int = 30
+    ) -> Tuple[str, str, int]:
+        """Execute *cmd* on the remote host.
+
+        Returns:
+            Tuple of ``(stdout, stderr, exit_code)``.
+
+        Raises:
+            :class:`SSHConnectionError`: If not connected or the command fails.
+        """
+        if not self.is_connected():
+            if self._settings is not None:
+                # Attempt auto-reconnect
+                logger.debug("SSH connection lost; attempting reconnect…")
+                await self.connect(self._settings)
+            else:
+                raise SSHConnectionError(
+                    "Not connected to remote host.  Call connect() first."
+                )
+
+        try:
+            result = await asyncio.wait_for(
+                self._connection.run(cmd, check=False),
+                timeout=timeout,
+            )
+            return (
+                result.stdout or "",
+                result.stderr or "",
+                result.exit_status if result.exit_status is not None else 0,
+            )
+        except asyncio.TimeoutError:
+            raise SSHConnectionError(
+                f"Remote command timed out after {timeout}s: {cmd!r}"
+            )
+        except Exception as exc:
+            self._is_connected = False
+            self._connection = None
+            raise SSHConnectionError(f"Remote command failed: {exc}") from exc
+
+    async def get_sftp(self) -> "asyncssh.SFTPClient":  # type: ignore[name-defined]
+        """Return an asyncssh SFTP client for the current connection.
+
+        The caller is responsible for closing the SFTP client (use as async
+        context manager: ``async with await manager.get_sftp() as sftp: ...``).
+        """
+        if not self.is_connected():
+            if self._settings is not None:
+                await self.connect(self._settings)
+            else:
+                raise SSHConnectionError("Not connected.")
+        return await self._connection.start_sftp_client()
+
+    def status_dict(self) -> dict:
+        """Return a JSON-serialisable connection status summary."""
+        return {
+            "connected": self.is_connected(),
+            "host": self._settings.remote_host if self._settings else None,
+            "user": self._settings.remote_user if self._settings else None,
+            "port": self._settings.remote_port if self._settings else None,
+            "connected_at": self._connected_at,
+            "asyncssh_available": _ASYNCSSH_AVAILABLE,
+        }
+
+    # ------------------------------------------------------------------ #
+    # Internal helpers                                                     #
+    # ------------------------------------------------------------------ #
+
+    async def _close_connections(self) -> None:
+        """Close main + jump connections without holding the lock."""
+        if self._connection is not None:
+            try:
+                self._connection.close()
+                await self._connection.wait_closed()
+            except Exception:
+                pass
+            self._connection = None
+        if self._jump_connection is not None:
+            try:
+                self._jump_connection.close()
+                await self._jump_connection.wait_closed()
+            except Exception:
+                pass
+            self._jump_connection = None
+        self._is_connected = False
+        self._connected_at = None
+
+
+# --------------------------------------------------------------------------- #
+# Helpers                                                                      #
+# --------------------------------------------------------------------------- #
+
+def _parse_jump_target(
+    jump_str: str, default_user: str
+) -> Tuple[str, int, str]:
+    """Parse a ProxyJump string like ``user@host:port`` into components.
+
+    Falls back to *default_user* and port 22 when not specified.
+    """
+    user = default_user
+    port = 22
+    host = jump_str
+
+    if "@" in jump_str:
+        user_part, host_part = jump_str.rsplit("@", 1)
+        user = user_part
+        host = host_part
+    else:
+        host_part = jump_str
+
+    if ":" in host:
+        host, port_str = host.rsplit(":", 1)
+        try:
+            port = int(port_str)
+        except ValueError:
+            pass
+
+    return host, port, user

--- a/qdashboard/remote/connection.py
+++ b/qdashboard/remote/connection.py
@@ -62,6 +62,11 @@ class SSHConnectionManager:
         self._connected_at: Optional[float] = None
         self._is_connected: bool = False
         self._lock: asyncio.Lock = asyncio.Lock()
+        # Separate from `_lock` (which guards close+create inside connect()/
+        # disconnect()) — this one coalesces concurrent auto-reconnect
+        # attempts from run()/get_sftp() so two overlapping callers don't
+        # each tear down and replace the connection out from under the other.
+        self._reconnect_lock: asyncio.Lock = asyncio.Lock()
 
     # ------------------------------------------------------------------ #
     # Public API                                                           #
@@ -160,6 +165,30 @@ class SSHConnectionManager:
             await self._close_connections()
             logger.info("SSH connection closed")
 
+    async def _ensure_connected(self) -> None:
+        """Reconnect if needed, coalescing concurrent reconnect attempts.
+
+        Multiple coroutines (background sync, route handlers, job
+        submission) share one manager. Without coalescing, two callers that
+        both observe ``is_connected() == False`` at the same time would each
+        call :meth:`connect`, and the second one's close-and-reopen would
+        yank the connection out from under the first — every in-flight
+        remote operation then fails with a "connection is closing" style
+        error. The double-checked lock here ensures only one of them
+        actually reconnects; the rest just wait and reuse the result.
+        """
+        if self.is_connected():
+            return
+        async with self._reconnect_lock:
+            if self.is_connected():
+                return
+            if self._settings is None:
+                raise SSHConnectionError(
+                    "Not connected to remote host.  Call connect() first."
+                )
+            logger.debug("SSH connection lost; attempting reconnect…")
+            await self.connect(self._settings)
+
     async def run(
         self, cmd: str, timeout: int = 30
     ) -> Tuple[str, str, int]:
@@ -171,15 +200,7 @@ class SSHConnectionManager:
         Raises:
             :class:`SSHConnectionError`: If not connected or the command fails.
         """
-        if not self.is_connected():
-            if self._settings is not None:
-                # Attempt auto-reconnect
-                logger.debug("SSH connection lost; attempting reconnect…")
-                await self.connect(self._settings)
-            else:
-                raise SSHConnectionError(
-                    "Not connected to remote host.  Call connect() first."
-                )
+        await self._ensure_connected()
 
         try:
             result = await asyncio.wait_for(
@@ -196,8 +217,14 @@ class SSHConnectionManager:
                 f"Remote command timed out after {timeout}s: {cmd!r}"
             )
         except Exception as exc:
-            self._is_connected = False
-            self._connection = None
+            # Only tear down the *shared* connection state if the connection
+            # itself is actually dead — a single rejected channel (e.g. the
+            # server's MaxSessions cap) is a transient, per-call failure and
+            # must not make every other concurrent caller think the whole
+            # connection is gone.
+            if self._connection is None or self._connection.is_closed():
+                self._is_connected = False
+                self._connection = None
             raise SSHConnectionError(f"Remote command failed: {exc}") from exc
 
     async def get_sftp(self) -> "asyncssh.SFTPClient":  # type: ignore[name-defined]
@@ -206,12 +233,14 @@ class SSHConnectionManager:
         The caller is responsible for closing the SFTP client (use as async
         context manager: ``async with await manager.get_sftp() as sftp: ...``).
         """
-        if not self.is_connected():
-            if self._settings is not None:
-                await self.connect(self._settings)
-            else:
-                raise SSHConnectionError("Not connected.")
-        return await self._connection.start_sftp_client()
+        await self._ensure_connected()
+        try:
+            return await self._connection.start_sftp_client()
+        except Exception as exc:
+            if self._connection is None or self._connection.is_closed():
+                self._is_connected = False
+                self._connection = None
+            raise SSHConnectionError(f"Failed to open SFTP session: {exc}") from exc
 
     def status_dict(self) -> dict:
         """Return a JSON-serialisable connection status summary."""

--- a/qdashboard/remote/executor.py
+++ b/qdashboard/remote/executor.py
@@ -1,0 +1,189 @@
+"""
+Command executor abstraction and SLURM client.
+
+Provides a uniform interface for running shell commands either locally
+(via asyncio subprocess) or on a remote host (via SSHConnectionManager).
+The ``RemoteSlurmClient`` wraps the SLURM commands through either executor.
+"""
+
+import asyncio
+from typing import List, Tuple
+
+from ..utils.logger import get_logger
+
+logger = get_logger(__name__)
+
+
+# --------------------------------------------------------------------------- #
+# Executor base classes                                                        #
+# --------------------------------------------------------------------------- #
+
+class LocalExecutor:
+    """Run commands as local asyncio subprocesses."""
+
+    async def run(self, cmd: str, timeout: int = 30) -> Tuple[str, str, int]:
+        """Execute *cmd* in a local shell.
+
+        Returns:
+            ``(stdout, stderr, exit_code)``
+        """
+        try:
+            proc = await asyncio.create_subprocess_shell(
+                cmd,
+                stdout=asyncio.subprocess.PIPE,
+                stderr=asyncio.subprocess.PIPE,
+            )
+            stdout_b, stderr_b = await asyncio.wait_for(
+                proc.communicate(), timeout=timeout
+            )
+            return stdout_b.decode(errors="replace"), stderr_b.decode(errors="replace"), proc.returncode
+        except asyncio.TimeoutError:
+            try:
+                proc.kill()
+            except Exception:
+                pass
+            return "", f"Command timed out after {timeout}s", -1
+        except Exception as exc:
+            return "", str(exc), -1
+
+
+class RemoteExecutor:
+    """Run commands via :class:`~qdashboard.remote.connection.SSHConnectionManager`."""
+
+    def __init__(self, ssh_manager) -> None:
+        self._manager = ssh_manager
+
+    async def run(self, cmd: str, timeout: int = 30) -> Tuple[str, str, int]:
+        """Execute *cmd* on the remote host.
+
+        Returns:
+            ``(stdout, stderr, exit_code)``
+        """
+        return await self._manager.run(cmd, timeout=timeout)
+
+
+def get_executor(settings, ssh_manager):
+    """Return the appropriate executor for the current execution mode.
+
+    Args:
+        settings: :class:`~qdashboard.remote.settings.RemoteSettings` instance.
+        ssh_manager: :class:`~qdashboard.remote.connection.SSHConnectionManager`
+            instance attached to ``app.state``.
+
+    Returns:
+        :class:`LocalExecutor` or :class:`RemoteExecutor`.
+    """
+    if settings.is_remote():
+        return RemoteExecutor(ssh_manager)
+    return LocalExecutor()
+
+
+# --------------------------------------------------------------------------- #
+# SLURM client                                                                 #
+# --------------------------------------------------------------------------- #
+
+class RemoteSlurmClient:
+    """
+    SLURM command wrapper that executes via a :class:`LocalExecutor` or
+    :class:`RemoteExecutor`.
+
+    This replaces the direct ``subprocess`` calls in ``qpu/slurm.py`` when
+    running in remote mode.
+    """
+
+    #: SLURM states that mean a job is still alive in the queue
+    ACTIVE_STATES = frozenset(
+        {"PENDING", "RUNNING", "COMPLETING", "CONFIGURING", "RESIZING", "SUSPENDED"}
+    )
+
+    def __init__(self, executor) -> None:
+        self._exec = executor
+
+    async def get_queue(self) -> List[dict]:
+        """Return the current SLURM queue as a list of job dicts."""
+        stdout, _, rc = await self._exec.run(
+            "squeue --format='%i %.18j %.8u %.8T %.10M %.9l %.6D %P %R' --noheader",
+            timeout=15,
+        )
+        if rc != 0:
+            return []
+
+        jobs = []
+        for line in stdout.strip().splitlines():
+            # Strip surrounding quotes that some squeue versions emit
+            line = line.strip("'\" ")
+            parts = line.split()
+            if len(parts) >= 8 and parts[7] != "sim":
+                jobs.append(
+                    {
+                        "job_id": parts[0],
+                        "name": parts[1],
+                        "user": parts[2],
+                        "state": parts[3],
+                        "time": parts[4],
+                        "time_limit": parts[5],
+                        "nodes": parts[6],
+                        "partition": parts[7],
+                        "nodelist": " ".join(parts[8:]),
+                    }
+                )
+        return jobs
+
+    async def check_job_status(self, job_id: str) -> str:
+        """Return the SLURM state of *job_id*, or ``'UNKNOWN'`` if not in queue."""
+        stdout, _, _ = await self._exec.run(
+            f"squeue -j {job_id} --noheader --format=%T",
+            timeout=10,
+        )
+        lines = [ln.strip() for ln in stdout.splitlines() if ln.strip()]
+        return lines[0] if lines else "UNKNOWN"
+
+    async def submit(self, script_path: str) -> Tuple[bool, str, str]:
+        """Submit *script_path* via ``sbatch``.
+
+        Returns:
+            ``(success, message, job_id)`` — *job_id* is empty on failure.
+        """
+        stdout, stderr, rc = await self._exec.run(
+            f"sbatch {script_path}", timeout=30
+        )
+        if rc == 0:
+            job_id = ""
+            for line in stdout.splitlines():
+                if "Submitted batch job" in line:
+                    job_id = line.split()[-1]
+                    break
+            logger.info("SLURM job submitted: job_id=%s", job_id)
+            return True, stdout.strip(), job_id
+        logger.error("sbatch failed (rc=%d): %s", rc, stderr.strip())
+        return False, stderr.strip(), ""
+
+    async def cancel(self, job_id: str) -> Tuple[bool, str]:
+        """Cancel a SLURM job via ``scancel``.
+
+        Returns:
+            ``(success, message)``
+        """
+        _, stderr, rc = await self._exec.run(
+            f"scancel {job_id}", timeout=15
+        )
+        if rc == 0:
+            return True, "Job cancelled."
+        return False, stderr.strip()
+
+    async def run_direct(self, cmd: str, timeout: int = 3600) -> Tuple[bool, str]:
+        """Run *cmd* directly (no sbatch) — used in ``*_direct`` execution modes.
+
+        The command is launched via ``nohup … &`` so it continues running
+        after the SSH session ends.  Returns immediately; no job ID is
+        available.
+
+        Returns:
+            ``(success, message)``
+        """
+        wrapped = f"nohup {cmd} > /dev/null 2>&1 & echo $!"
+        stdout, stderr, rc = await self._exec.run(wrapped, timeout=30)
+        if rc == 0:
+            pid = stdout.strip()
+            return True, f"Process started (PID {pid})"
+        return False, stderr.strip()

--- a/qdashboard/remote/file_sync.py
+++ b/qdashboard/remote/file_sync.py
@@ -9,6 +9,7 @@ history queries, and DB operations work entirely locally.
 
 import asyncio
 import os
+import shutil
 from typing import List, Tuple
 
 from ..utils.logger import get_logger
@@ -37,9 +38,14 @@ def _expand_remote(path: str, remote_home: str) -> str:
 
 
 async def _sftp_download_dir(
-    sftp, remote_dir: str, local_dir: str
+    sftp, remote_dir: str, local_dir: str, mirror: bool = False
 ) -> List[str]:
     """Recursively download *remote_dir* into *local_dir* via SFTP.
+
+    When *mirror* is True, local entries with no corresponding remote entry
+    are deleted afterwards, so *local_dir* ends up an exact copy of
+    *remote_dir* (used for the read-only platforms mirror, where stale
+    files/directories left behind by a remote branch switch must not linger).
 
     Returns the list of local paths written.
     """
@@ -58,16 +64,18 @@ async def _sftp_download_dir(
         logger.debug("Cannot list remote dir %s: %s", remote_dir, exc)
         return copied
 
+    remote_names = set()
     for entry in entries:
         name = entry.filename
         if name in (".", ".."):
             continue
+        remote_names.add(name)
         remote_path = f"{remote_dir}/{name}"
         local_path = os.path.join(local_dir, name)
 
         # Directory — recurse
         if entry.attrs.type == asyncssh.FILEXFER_TYPE_DIRECTORY:
-            sub = await _sftp_download_dir(sftp, remote_path, local_path)
+            sub = await _sftp_download_dir(sftp, remote_path, local_path, mirror=mirror)
             copied.extend(sub)
         else:
             try:
@@ -77,6 +85,19 @@ async def _sftp_download_dir(
                 logger.warning(
                     "SFTP get failed for %s → %s: %s", remote_path, local_path, exc
                 )
+
+    if mirror:
+        for name in os.listdir(local_dir):
+            if name in remote_names:
+                continue
+            stale_path = os.path.join(local_dir, name)
+            try:
+                if os.path.isdir(stale_path):
+                    shutil.rmtree(stale_path)
+                else:
+                    os.remove(stale_path)
+            except OSError as exc:
+                logger.warning("Failed to remove stale mirror entry %s: %s", stale_path, exc)
 
     return copied
 

--- a/qdashboard/remote/file_sync.py
+++ b/qdashboard/remote/file_sync.py
@@ -1,0 +1,264 @@
+"""
+Experiment data synchronisation — pull results from the remote to local storage.
+
+After a job completes on the remote cluster the ``output/`` directory (qibocal
+results), ``runcard.yml``, and ``experiment_metadata.json`` are downloaded
+via asyncssh SFTP into the local ``data_dir`` so that all visualisation,
+history queries, and DB operations work entirely locally.
+"""
+
+import asyncio
+import os
+from typing import List, Tuple
+
+from ..utils.logger import get_logger
+
+logger = get_logger(__name__)
+
+
+# --------------------------------------------------------------------------- #
+# Low-level SFTP helpers                                                       #
+# --------------------------------------------------------------------------- #
+
+async def _resolve_remote_home(ssh_manager) -> str:
+    """Return the home directory on the remote machine."""
+    try:
+        stdout, _, _ = await ssh_manager.run("echo $HOME", timeout=10)
+        return stdout.strip()
+    except Exception:
+        return ""
+
+
+def _expand_remote(path: str, remote_home: str) -> str:
+    """Expand a leading ``~`` in *path* using *remote_home*."""
+    if path.startswith("~/") or path == "~":
+        return path.replace("~", remote_home, 1)
+    return path
+
+
+async def _sftp_download_dir(
+    sftp, remote_dir: str, local_dir: str
+) -> List[str]:
+    """Recursively download *remote_dir* into *local_dir* via SFTP.
+
+    Returns the list of local paths written.
+    """
+    try:
+        import asyncssh  # type: ignore[import]
+    except ImportError:
+        logger.error("asyncssh not available; cannot download via SFTP.")
+        return []
+
+    os.makedirs(local_dir, exist_ok=True)
+    copied: List[str] = []
+
+    try:
+        entries = await sftp.readdir(remote_dir)
+    except Exception as exc:
+        logger.debug("Cannot list remote dir %s: %s", remote_dir, exc)
+        return copied
+
+    for entry in entries:
+        name = entry.filename
+        if name in (".", ".."):
+            continue
+        remote_path = f"{remote_dir}/{name}"
+        local_path = os.path.join(local_dir, name)
+
+        # Directory — recurse
+        if entry.attrs.type == asyncssh.FILEXFER_TYPE_DIRECTORY:
+            sub = await _sftp_download_dir(sftp, remote_path, local_path)
+            copied.extend(sub)
+        else:
+            try:
+                await sftp.get(remote_path, local_path)
+                copied.append(local_path)
+            except Exception as exc:
+                logger.warning(
+                    "SFTP get failed for %s → %s: %s", remote_path, local_path, exc
+                )
+
+    return copied
+
+
+# --------------------------------------------------------------------------- #
+# Public sync functions                                                        #
+# --------------------------------------------------------------------------- #
+
+async def sync_experiment_from_remote(
+    experiment_id: str,
+    platform: str,
+    date_str: str,
+    settings,
+    ssh_manager,
+    local_data_dir: str,
+) -> List[str]:
+    """Pull one experiment's data from the remote to *local_data_dir*.
+
+    Downloads ``output/``, ``runcard.yml``, and ``experiment_metadata.json``
+    (skipping files that already exist locally).
+
+    Returns:
+        List of local file paths that were written.
+    """
+    try:
+        sftp = await ssh_manager.get_sftp()
+    except Exception as exc:
+        logger.error("Cannot open SFTP client: %s", exc)
+        return []
+
+    remote_home = await _resolve_remote_home(ssh_manager)
+    remote_exp_dir = _expand_remote(
+        f"{settings.remote_root}/{platform}/{date_str}/{experiment_id}",
+        remote_home,
+    )
+    local_exp_dir = os.path.abspath(
+        os.path.join(local_data_dir, platform, date_str, experiment_id)
+    )
+    os.makedirs(local_exp_dir, exist_ok=True)
+
+    copied: List[str] = []
+
+    async with sftp:
+        # Download the qibocal output directory
+        remote_output = f"{remote_exp_dir}/output"
+        local_output = os.path.join(local_exp_dir, "output")
+        output_files = await _sftp_download_dir(sftp, remote_output, local_output)
+        copied.extend(output_files)
+
+        # Download ancillary files (skip if already present locally)
+        for fname in ("experiment_metadata.json", "runcard.yml"):
+            local_file = os.path.join(local_exp_dir, fname)
+            if os.path.exists(local_file):
+                continue
+            remote_file = f"{remote_exp_dir}/{fname}"
+            try:
+                await sftp.get(remote_file, local_file)
+                copied.append(local_file)
+            except Exception:
+                pass  # file may not exist; non-fatal
+
+    logger.info(
+        "Synced %d file(s) for experiment %s", len(copied), experiment_id
+    )
+    return copied
+
+
+async def check_remote_experiment_complete(
+    experiment_id: str,
+    platform: str,
+    date_str: str,
+    settings,
+    ssh_manager,
+) -> bool:
+    """Return ``True`` if ``output/meta.json`` exists on the remote."""
+    remote_home = await _resolve_remote_home(ssh_manager)
+    remote_exp_dir = _expand_remote(
+        f"{settings.remote_root}/{platform}/{date_str}/{experiment_id}",
+        remote_home,
+    )
+    meta_path = f"{remote_exp_dir}/output/meta.json"
+    stdout, _, _ = await ssh_manager.run(
+        f"test -f {meta_path} && echo exists || echo missing",
+        timeout=10,
+    )
+    return stdout.strip() == "exists"
+
+
+async def sync_all_completed(
+    settings,
+    ssh_manager,
+    local_data_dir: str,
+) -> dict:
+    """Scan the remote data directory and pull any completed experiments that are
+    not yet fully present locally.
+
+    Returns:
+        Dict with ``synced`` (int) and ``errors`` (int) counts.
+    """
+    remote_home = await _resolve_remote_home(ssh_manager)
+    remote_data_dir = _expand_remote(
+        f"{settings.remote_root}/data",
+        remote_home,
+    )
+
+    stdout, _, rc = await ssh_manager.run(
+        f"find {remote_data_dir} -name 'experiment_metadata.json' 2>/dev/null",
+        timeout=30,
+    )
+    if rc != 0 and not stdout.strip():
+        return {"synced": 0, "errors": 0}
+
+    synced = 0
+    errors = 0
+    for metadata_path in stdout.strip().splitlines():
+        # Expected layout:  remote_data_dir/<platform>/<date>/<exp_id>/experiment_metadata.json
+        parts = metadata_path.split("/")
+        if len(parts) < 4:
+            continue
+        experiment_id = parts[-2]
+        date_str = parts[-3]
+        platform = parts[-4]
+
+        # Skip if already fully synced (output/meta.json exists locally)
+        local_meta = os.path.join(
+            local_data_dir, platform, date_str, experiment_id, "output", "meta.json"
+        )
+        if os.path.exists(local_meta):
+            continue
+
+        # Only sync if the experiment is actually complete on the remote
+        complete = await check_remote_experiment_complete(
+            experiment_id, platform, date_str, settings, ssh_manager
+        )
+        if not complete:
+            continue
+
+        try:
+            files = await sync_experiment_from_remote(
+                experiment_id, platform, date_str,
+                settings, ssh_manager, local_data_dir,
+            )
+            if files:
+                synced += 1
+        except Exception as exc:
+            logger.warning("Sync failed for %s: %s", experiment_id, exc)
+            errors += 1
+
+    return {"synced": synced, "errors": errors}
+
+
+# --------------------------------------------------------------------------- #
+# SFTP upload helpers (used during remote submission)                          #
+# --------------------------------------------------------------------------- #
+
+async def sftp_upload_file(
+    local_path: str, remote_path: str, ssh_manager
+) -> None:
+    """Upload a single local file to *remote_path* via SFTP."""
+    sftp = await ssh_manager.get_sftp()
+    async with sftp:
+        # Ensure the remote directory exists
+        remote_dir = "/".join(remote_path.split("/")[:-1])
+        if remote_dir:
+            await sftp.makedirs(remote_dir, exist_ok=True)
+        await sftp.put(local_path, remote_path)
+
+
+async def sftp_upload_text(
+    content: str, remote_path: str, ssh_manager
+) -> None:
+    """Write *content* as a UTF-8 text file at *remote_path* via SFTP."""
+    import tempfile
+
+    with tempfile.NamedTemporaryFile(mode="w", suffix=".tmp", delete=False) as tmp:
+        tmp.write(content)
+        tmp_path = tmp.name
+
+    try:
+        await sftp_upload_file(tmp_path, remote_path, ssh_manager)
+    finally:
+        try:
+            os.unlink(tmp_path)
+        except OSError:
+            pass

--- a/qdashboard/remote/platforms_git.py
+++ b/qdashboard/remote/platforms_git.py
@@ -1,0 +1,555 @@
+"""
+Remote-host git operations for the qibolab platforms repository, plus the
+local read-only mirror sync.
+
+Mirrors the shape of the sync, subprocess-based functions in
+``qdashboard/qpu/platforms.py`` but executes every git command on the remote
+host via :class:`~qdashboard.remote.connection.SSHConnectionManager`, so that
+when ``execution_mode`` is ``remote_*`` all git mutations (branch switch,
+commit, stash, discard, push) happen on the machine that actually owns the
+platform files — never on the local dashboard host.
+
+Local mode is completely unaffected: ``qpu/platforms.py`` keeps running
+unmodified subprocess-based git commands against the local checkout.
+"""
+
+import os
+import shlex
+import shutil
+from typing import List, Optional
+
+from ..utils.logger import get_logger
+from .file_sync import _resolve_remote_home, _expand_remote, _sftp_download_dir, sftp_upload_text
+
+logger = get_logger(__name__)
+
+
+def _q(value: str) -> str:
+    """Shell-quote a value for interpolation into a remote command string."""
+    return shlex.quote(value)
+
+
+# --------------------------------------------------------------------------- #
+# Path resolution                                                              #
+# --------------------------------------------------------------------------- #
+
+async def resolve_remote_platforms_path(settings, ssh_manager) -> str:
+    """Resolve the qibolab platforms directory on the remote host.
+
+    Resolution order:
+      1. ``settings.remote_platforms_path`` (with ``~`` expanded to the
+         remote ``$HOME``), if set.
+      2. The remote host's own ``$QIBOLAB_PLATFORMS`` environment variable.
+      3. ``~/qibolab_platforms_qrc`` on the remote host.
+    """
+    remote_home = await _resolve_remote_home(ssh_manager)
+
+    if settings.remote_platforms_path:
+        return _expand_remote(settings.remote_platforms_path, remote_home)
+
+    try:
+        stdout, _, rc = await ssh_manager.run("echo $QIBOLAB_PLATFORMS", timeout=10)
+        env_path = stdout.strip()
+        if rc == 0 and env_path:
+            return env_path
+    except Exception as exc:
+        logger.debug("Could not read remote $QIBOLAB_PLATFORMS: %s", exc)
+
+    return _expand_remote("~/qibolab_platforms_qrc", remote_home)
+
+
+async def write_remote_file(ssh_manager, platforms_path: str, relative_path: str, content: str) -> None:
+    """Write *content* to ``platforms_path/relative_path`` on the remote host.
+
+    Used for non-git config edits (``parameters.json``, ``action_nodes.json``)
+    made through the dashboard's JSON editors — these must land on the actual
+    remote file, never on the local read-only mirror, or the edit would be
+    silently discarded on the next mirror sync.
+    """
+    remote_path = f"{platforms_path.rstrip('/')}/{relative_path}"
+    await sftp_upload_text(content, remote_path, ssh_manager)
+
+
+# --------------------------------------------------------------------------- #
+# Mirror sync                                                                  #
+# --------------------------------------------------------------------------- #
+
+async def sync_platforms_mirror(settings, ssh_manager, mirror_dir: str) -> dict:
+    """Mirror the remote platforms directory into *mirror_dir* via SFTP.
+
+    The mirror is a plain file cache (no ``.git``) used for fast local reads
+    (QPU monitoring, topology, ``queues.json`` partition lookup) — it is never
+    written to directly, and no git command is ever run against it locally.
+
+    Returns ``{'success': bool, 'files_synced': int, 'error': str|None}``.
+    """
+    try:
+        remote_path = await resolve_remote_platforms_path(settings, ssh_manager)
+        sftp = await ssh_manager.get_sftp()
+    except Exception as exc:
+        logger.warning("Cannot sync platforms mirror: %s", exc)
+        return {'success': False, 'files_synced': 0, 'error': str(exc)}
+
+    os.makedirs(mirror_dir, exist_ok=True)
+    copied: List[str] = []
+    try:
+        import asyncssh  # type: ignore[import]
+
+        async with sftp:
+            entries = await sftp.readdir(remote_path)
+            # Download everything except .git (walk manually so we can skip it)
+            for entry in entries:
+                name = entry.filename
+                if name in ('.', '..', '.git'):
+                    continue
+                remote_entry_path = f"{remote_path}/{name}"
+                local_entry_path = os.path.join(mirror_dir, name)
+                if entry.attrs.type == asyncssh.FILEXFER_TYPE_DIRECTORY:
+                    copied.extend(
+                        await _sftp_download_dir(sftp, remote_entry_path, local_entry_path, mirror=True)
+                    )
+                else:
+                    try:
+                        await sftp.get(remote_entry_path, local_entry_path)
+                        copied.append(local_entry_path)
+                    except Exception as exc:
+                        logger.warning("SFTP get failed for %s: %s", remote_entry_path, exc)
+
+        # Prune stale top-level entries no longer present on the remote (skip .git — we never write it)
+        remote_names = {e.filename for e in entries if e.filename not in ('.', '..')}
+        remote_names.add('.git')
+        for name in os.listdir(mirror_dir):
+            if name in remote_names:
+                continue
+            stale_path = os.path.join(mirror_dir, name)
+            try:
+                if os.path.isdir(stale_path):
+                    shutil.rmtree(stale_path)
+                else:
+                    os.remove(stale_path)
+            except OSError as exc:
+                logger.warning("Failed to remove stale mirror entry %s: %s", stale_path, exc)
+
+        logger.info("Synced %d file(s) into platforms mirror: %s", len(copied), mirror_dir)
+        return {'success': True, 'files_synced': len(copied), 'error': None}
+    except Exception as exc:
+        logger.warning("Platforms mirror sync failed: %s", exc)
+        return {'success': False, 'files_synced': len(copied), 'error': str(exc)}
+
+
+# --------------------------------------------------------------------------- #
+# Git read/write operations (executed on the remote host)                     #
+# --------------------------------------------------------------------------- #
+
+async def _is_git_repo(ssh_manager, platforms_path: str) -> bool:
+    _, _, rc = await ssh_manager.run(f"test -d {_q(platforms_path)}/.git", timeout=10)
+    return rc == 0
+
+
+async def list_repository_branches(ssh_manager, platforms_path: str) -> Optional[dict]:
+    """Remote equivalent of ``qpu.platforms.list_repository_branches``."""
+    if not await _is_git_repo(ssh_manager, platforms_path):
+        logger.warning("Not a git repository (remote): %s", platforms_path)
+        return None
+
+    path_q = _q(platforms_path)
+    try:
+        stdout, _, rc = await ssh_manager.run(f"git -C {path_q} branch --show-current", timeout=15)
+        current_branch = stdout.strip()
+
+        stdout, _, rc = await ssh_manager.run(
+            f"git -C {path_q} branch --format='%(refname:short)'", timeout=15
+        )
+        local_branches = [b.strip() for b in stdout.splitlines() if b.strip()]
+
+        await ssh_manager.run(f"git -C {path_q} fetch --all", timeout=30)
+
+        stdout, _, rc = await ssh_manager.run(
+            f"git -C {path_q} branch -r --format='%(refname:short)'", timeout=15
+        )
+        remote_branches = [
+            b.strip() for b in stdout.splitlines()
+            if b.strip() and not b.strip().endswith('/HEAD')
+        ]
+
+        return {'current': current_branch, 'local': local_branches, 'remote': remote_branches}
+    except Exception as exc:
+        logger.error("Unexpected error listing remote branches: %s", exc)
+        return None
+
+
+async def get_current_branch_info(ssh_manager, platforms_path: str) -> Optional[dict]:
+    """Remote equivalent of ``qpu.platforms.get_current_branch_info``."""
+    if not await _is_git_repo(ssh_manager, platforms_path):
+        logger.warning("Not a git repository (remote): %s", platforms_path)
+        return None
+
+    path_q = _q(platforms_path)
+    try:
+        stdout, _, _ = await ssh_manager.run(f"git -C {path_q} branch --show-current", timeout=15)
+        current_branch = stdout.strip()
+
+        stdout, _, _ = await ssh_manager.run(f"git -C {path_q} rev-parse --short HEAD", timeout=15)
+        current_commit = stdout.strip()
+
+        stdout, _, _ = await ssh_manager.run(
+            f"git -C {path_q} log -1 --pretty=format:%s", timeout=15
+        )
+        commit_message = stdout.strip()
+
+        stdout, _, _ = await ssh_manager.run(f"git -C {path_q} status --porcelain", timeout=15)
+        is_clean = not bool(stdout.strip())
+
+        ahead, behind = 0, 0
+        try:
+            await ssh_manager.run(f"git -C {path_q} fetch", timeout=30)
+            stdout, _, rc = await ssh_manager.run(
+                f"git -C {path_q} rev-parse --abbrev-ref {shlex.quote(current_branch)}@{{upstream}}",
+                timeout=15,
+            )
+            if rc == 0:
+                upstream_branch = stdout.strip()
+                stdout, _, rc = await ssh_manager.run(
+                    f"git -C {path_q} rev-list --left-right --count "
+                    f"{shlex.quote(upstream_branch)}...{shlex.quote(current_branch)}",
+                    timeout=15,
+                )
+                if rc == 0 and stdout.strip():
+                    behind, ahead = map(int, stdout.strip().split())
+        except Exception:
+            pass
+
+        return {
+            'branch': current_branch,
+            'commit': current_commit,
+            'commit_message': commit_message,
+            'behind': behind,
+            'ahead': ahead,
+            'clean': is_clean,
+        }
+    except Exception as exc:
+        logger.error("Unexpected error getting remote branch info: %s", exc)
+        return None
+
+
+async def switch_repository_branch(
+    ssh_manager, platforms_path: str, branch_name: str,
+    create_if_not_exists: bool = False, handle_changes: str = 'fail',
+    auto_apply_stash: bool = True,
+) -> dict:
+    """Remote equivalent of ``qpu.platforms.switch_repository_branch``."""
+    if not await _is_git_repo(ssh_manager, platforms_path):
+        logger.warning("Not a git repository (remote): %s", platforms_path)
+        return {'success': False, 'error': 'Not a git repository'}
+
+    path_q = _q(platforms_path)
+    branch_q = _q(branch_name)
+    result = {
+        'success': False, 'has_changes': False, 'changes_handled': None,
+        'stash_created': None, 'stash_applied': None, 'stash_restored': False,
+    }
+
+    try:
+        await ssh_manager.run(f"git -C {path_q} fetch --all", timeout=30)
+
+        stdout, _, _ = await ssh_manager.run(f"git -C {path_q} status --porcelain", timeout=15)
+        has_local_changes = bool(stdout.strip())
+        result['has_changes'] = has_local_changes
+
+        if has_local_changes:
+            if handle_changes == 'fail':
+                result['error'] = 'Local changes detected. Please choose how to handle them.'
+                return result
+            elif handle_changes == 'stash':
+                stash_result = await stash_changes(
+                    ssh_manager, platforms_path, f"Auto-stash before switching to {branch_name}"
+                )
+                if not stash_result['success']:
+                    result['error'] = f"Failed to stash changes: {stash_result.get('error', 'Unknown error')}"
+                    return result
+                result['changes_handled'] = 'stashed'
+                result['stash_created'] = stash_result.get('stash_name')
+            elif handle_changes == 'commit':
+                result['error'] = 'Commit option requires explicit commit message handling'
+                return result
+
+        _, _, local_rc = await ssh_manager.run(
+            f"git -C {path_q} show-ref --verify --quiet refs/heads/{branch_q}", timeout=10
+        )
+        branch_exists_locally = local_rc == 0
+
+        _, _, remote_rc = await ssh_manager.run(
+            f"git -C {path_q} show-ref --verify --quiet refs/remotes/origin/{branch_q}", timeout=10
+        )
+        branch_exists_remotely = remote_rc == 0
+
+        if branch_exists_locally:
+            _, stderr, rc = await ssh_manager.run(f"git -C {path_q} checkout {branch_q}", timeout=30)
+        elif branch_exists_remotely:
+            _, stderr, rc = await ssh_manager.run(
+                f"git -C {path_q} checkout -b {branch_q} origin/{branch_q}", timeout=30
+            )
+        elif create_if_not_exists:
+            _, stderr, rc = await ssh_manager.run(f"git -C {path_q} checkout -b {branch_q}", timeout=30)
+        else:
+            result['error'] = f"Branch '{branch_name}' not found locally or remotely"
+            return result
+
+        if rc != 0:
+            result['error'] = f"Failed to switch branch: {stderr.strip()}"
+            return result
+
+        if branch_exists_locally or branch_exists_remotely:
+            await ssh_manager.run(f"git -C {path_q} pull", timeout=30)
+
+        result['success'] = True
+
+        if auto_apply_stash:
+            stash_result = await apply_latest_stash(ssh_manager, platforms_path, pop=True)
+            if stash_result['success']:
+                result['stash_applied'] = stash_result.get('stash_applied')
+                result['stash_restored'] = True
+            # No stashes, or apply failed — non-fatal either way.
+
+        return result
+    except Exception as exc:
+        logger.error("Unexpected error switching remote branch: %s", exc)
+        result['error'] = f"Unexpected error switching branch: {exc}"
+        return result
+
+
+async def stash_changes(ssh_manager, platforms_path: str, stash_message: str = "WIP: Temporary stash") -> dict:
+    """Remote equivalent of ``qpu.platforms.stash_changes``."""
+    if not await _is_git_repo(ssh_manager, platforms_path):
+        return {'success': False, 'error': 'Not a git repository'}
+
+    path_q = _q(platforms_path)
+    try:
+        stdout, _, _ = await ssh_manager.run(f"git -C {path_q} status --porcelain", timeout=15)
+        if not stdout.strip():
+            return {'success': False, 'error': 'No changes to stash'}
+
+        _, stderr, rc = await ssh_manager.run(
+            f"git -C {path_q} stash push -u -m {_q(stash_message)}", timeout=30
+        )
+        if rc != 0:
+            return {'success': False, 'error': f"Failed to stash changes: {stderr.strip()}"}
+
+        stdout, _, _ = await ssh_manager.run(
+            f"git -C {path_q} stash list --oneline -1", timeout=15
+        )
+        stash_name = stdout.split(':')[0].strip() if stdout else 'stash@{0}'
+
+        return {'success': True, 'stash_name': stash_name}
+    except Exception as exc:
+        logger.error("Unexpected error during remote stash: %s", exc)
+        return {'success': False, 'error': str(exc)}
+
+
+async def apply_latest_stash(ssh_manager, platforms_path: str, pop: bool = True) -> dict:
+    """Remote equivalent of ``qpu.platforms.apply_latest_stash``."""
+    if not await _is_git_repo(ssh_manager, platforms_path):
+        return {'success': False, 'error': 'Not a git repository'}
+
+    path_q = _q(platforms_path)
+    try:
+        stdout, _, _ = await ssh_manager.run(f"git -C {path_q} stash list", timeout=15)
+        if not stdout.strip():
+            return {'success': False, 'error': 'No stashes available'}
+
+        latest_stash = stdout.splitlines()[0].split(':')[0]
+
+        stash_command = 'pop' if pop else 'apply'
+        stdout, stderr, rc = await ssh_manager.run(f"git -C {path_q} stash {stash_command}", timeout=30)
+
+        conflicts = rc != 0
+        if conflicts:
+            return {
+                'success': True, 'stash_applied': latest_stash, 'conflicts': True,
+                'error': f"Applied with conflicts: {stderr.strip()}",
+            }
+        return {'success': True, 'stash_applied': latest_stash, 'conflicts': False}
+    except Exception as exc:
+        logger.error("Unexpected error applying remote stash: %s", exc)
+        return {'success': False, 'error': str(exc)}
+
+
+async def discard_changes(ssh_manager, platforms_path: str) -> dict:
+    """Remote equivalent of ``qpu.platforms.discard_changes``."""
+    if not await _is_git_repo(ssh_manager, platforms_path):
+        return {'success': False, 'error': 'Not a git repository'}
+
+    path_q = _q(platforms_path)
+    try:
+        stdout, _, _ = await ssh_manager.run(f"git -C {path_q} status --porcelain", timeout=15)
+        changed_files = []
+        for line in stdout.splitlines():
+            if line.strip():
+                filename = line[3:].strip()
+                changed_files.append(filename)
+
+        if not changed_files:
+            return {'success': False, 'error': 'No changes to discard'}
+
+        _, stderr, rc = await ssh_manager.run(f"git -C {path_q} reset --hard HEAD", timeout=30)
+        if rc != 0:
+            return {'success': False, 'error': f"Failed to discard changes: {stderr.strip()}"}
+
+        _, stderr, rc = await ssh_manager.run(f"git -C {path_q} clean -fd", timeout=30)
+        if rc != 0:
+            return {'success': False, 'error': f"Failed to discard changes: {stderr.strip()}"}
+
+        return {'success': True, 'discarded_files': changed_files}
+    except Exception as exc:
+        logger.error("Unexpected error during remote discard: %s", exc)
+        return {'success': False, 'error': str(exc)}
+
+
+async def list_stashes(ssh_manager, platforms_path: str) -> dict:
+    """Remote equivalent of ``qpu.platforms.list_stashes``."""
+    if not await _is_git_repo(ssh_manager, platforms_path):
+        return {'success': False, 'error': 'Not a git repository'}
+
+    path_q = _q(platforms_path)
+    try:
+        stdout, stderr, rc = await ssh_manager.run(
+            f"git -C {path_q} stash list --pretty=format:'%gd: %gs (%cr)'", timeout=15
+        )
+        if rc != 0:
+            return {'success': False, 'error': f"Failed to list stashes: {stderr.strip()}"}
+
+        stashes = []
+        for line in stdout.splitlines():
+            if line.strip():
+                parts = line.split(': ', 2)
+                if len(parts) >= 2:
+                    stashes.append({
+                        'name': parts[0],
+                        'message': parts[1] if len(parts) == 2 else parts[1],
+                        'date': parts[2] if len(parts) == 3 else '',
+                    })
+        return {'success': True, 'stashes': stashes}
+    except Exception as exc:
+        logger.error("Unexpected error listing remote stashes: %s", exc)
+        return {'success': False, 'error': str(exc)}
+
+
+async def _changed_files(ssh_manager, platforms_path: str) -> List[str]:
+    """Return changed file paths (relative to repo root) on the remote host."""
+    stdout, _, _ = await ssh_manager.run(f"git -C {_q(platforms_path)} status --porcelain", timeout=15)
+    files = []
+    for line in stdout.splitlines():
+        if not line.strip():
+            continue
+        path = line[3:].strip()
+        if ' -> ' in path:
+            path = path.split(' -> ')[-1]
+        files.append(path)
+    return files
+
+
+async def generate_commit_message(ssh_manager, platforms_path: str) -> str:
+    """Remote equivalent of ``qpu.platforms.generate_commit_message``."""
+    files = await _changed_files(ssh_manager, platforms_path)
+    if not files:
+        return ""
+
+    kind_by_filename = {
+        'platform.py': 'configuration',
+        'calibration.json': 'calibration',
+        'parameters.json': 'parameters',
+    }
+    kind_order = ['configuration', 'calibration', 'parameters']
+
+    changes_by_platform = {}
+    other_files = []
+    for file_path in files:
+        parts = file_path.split('/')
+        if len(parts) < 2:
+            other_files.append(file_path)
+            continue
+        platform_name, filename = parts[0], parts[-1]
+        kind = kind_by_filename.get(filename)
+        if kind:
+            changes_by_platform.setdefault(platform_name, set()).add(kind)
+        else:
+            other_files.append(file_path)
+
+    platform_summaries = []
+    for platform_name in sorted(changes_by_platform):
+        kinds = changes_by_platform[platform_name]
+        ordered_kinds = [k for k in kind_order if k in kinds]
+        platform_summaries.append(f"{platform_name} ({', '.join(ordered_kinds)})")
+
+    message = "Update " + "; ".join(platform_summaries) if platform_summaries else "Update platform configurations"
+    if other_files:
+        message += f" [+{len(other_files)} other file(s)]"
+    return message
+
+
+async def commit_changes(ssh_manager, platforms_path: str, commit_message: Optional[str] = None) -> dict:
+    """Remote equivalent of ``qpu.platforms.commit_changes``."""
+    if not await _is_git_repo(ssh_manager, platforms_path):
+        return {'success': False, 'error': 'Not a git repository'}
+
+    path_q = _q(platforms_path)
+    try:
+        stdout, _, _ = await ssh_manager.run(f"git -C {path_q} status --porcelain", timeout=15)
+        if not stdout.strip():
+            return {'success': False, 'error': 'No changes to commit'}
+
+        if not commit_message:
+            commit_message = await generate_commit_message(ssh_manager, platforms_path)
+
+        _, stderr, rc = await ssh_manager.run(f"git -C {path_q} add .", timeout=30)
+        if rc != 0:
+            return {'success': False, 'error': f"Failed to stage changes: {stderr.strip()}"}
+
+        _, stderr, rc = await ssh_manager.run(
+            f"git -C {path_q} commit -m {_q(commit_message)}", timeout=30
+        )
+        if rc != 0:
+            return {'success': False, 'error': f"Failed to commit changes: {stderr.strip()}"}
+
+        stdout, _, _ = await ssh_manager.run(f"git -C {path_q} rev-parse --short HEAD", timeout=15)
+        commit_hash = stdout.strip()
+
+        branch_info = await get_current_branch_info(ssh_manager, platforms_path)
+
+        return {
+            'success': True, 'commit_hash': commit_hash,
+            'message': commit_message, 'branch_info': branch_info,
+        }
+    except Exception as exc:
+        logger.error("Unexpected error during remote commit: %s", exc)
+        return {'success': False, 'error': str(exc)}
+
+
+async def push_changes(ssh_manager, platforms_path: str) -> dict:
+    """Remote equivalent of ``qpu.platforms.push_changes``."""
+    if not await _is_git_repo(ssh_manager, platforms_path):
+        return {'success': False, 'error': 'Not a git repository'}
+
+    path_q = _q(platforms_path)
+    try:
+        stdout, _, _ = await ssh_manager.run(f"git -C {path_q} branch --show-current", timeout=15)
+        current_branch = stdout.strip()
+
+        stdout, _, rc = await ssh_manager.run(
+            f"git -C {path_q} rev-list --count origin/{shlex.quote(current_branch)}..HEAD", timeout=15
+        )
+        if rc == 0 and stdout.strip().isdigit() and int(stdout.strip()) == 0:
+            return {'success': False, 'error': 'No commits to push'}
+
+        _, stderr, rc = await ssh_manager.run(
+            f"git -C {path_q} push origin {shlex.quote(current_branch)}", timeout=60
+        )
+        if rc != 0:
+            return {'success': False, 'error': f"Failed to push changes: {stderr.strip()}"}
+
+        branch_info = await get_current_branch_info(ssh_manager, platforms_path)
+
+        return {'success': True, 'remote': 'origin', 'branch': current_branch, 'branch_info': branch_info}
+    except Exception as exc:
+        logger.error("Unexpected error during remote push: %s", exc)
+        return {'success': False, 'error': str(exc)}

--- a/qdashboard/remote/settings.py
+++ b/qdashboard/remote/settings.py
@@ -1,0 +1,122 @@
+"""
+Remote execution settings — persistence and access helpers.
+
+Settings are stored in ``<qd_root>/remote_settings.json`` so they can be
+updated at runtime via the Settings UI without requiring a server restart.
+"""
+
+import json
+import os
+from dataclasses import dataclass, asdict, fields as dc_fields
+from typing import Optional
+
+SETTINGS_FILE = "remote_settings.json"
+
+# Valid execution modes
+EXECUTION_MODES = frozenset(
+    {"local_slurm", "local_direct", "remote_slurm", "remote_direct"}
+)
+
+
+@dataclass
+class RemoteSettings:
+    """All settings that control how/where experiments are executed."""
+
+    # ------------------------------------------------------------------ #
+    # Execution mode                                                       #
+    # ------------------------------------------------------------------ #
+    # local_slurm   — existing behaviour: sbatch runs on this machine
+    # local_direct  — run `qq` directly on this machine (no sbatch)
+    # remote_slurm  — SSH to remote; submit via sbatch there
+    # remote_direct — SSH to remote; run `qq` directly there
+    execution_mode: str = "local_slurm"
+
+    # ------------------------------------------------------------------ #
+    # Remote server                                                        #
+    # ------------------------------------------------------------------ #
+    remote_host: str = ""
+    remote_user: str = ""
+    remote_port: int = 22
+    # Working root directory on the remote machine (~ is resolved on remote)
+    remote_root: str = "~/.qdashboard"
+    # Path to venv or conda env on the remote machine (e.g. ~/envs/qibocal)
+    remote_environment: str = ""
+    # Path to QIBOLAB_PLATFORMS on the remote machine.
+    # Leave empty to reuse the same path as the local QIBOLAB_PLATFORMS env var
+    # (works for NFS-mounted or identically-structured remote systems).
+    remote_platforms_path: str = ""
+
+    # ------------------------------------------------------------------ #
+    # SSH authentication                                                   #
+    # ------------------------------------------------------------------ #
+    # Path to the private key file on the LOCAL machine
+    ssh_key_path: str = ""
+    # Whether to attempt SSH agent authentication in addition to key file
+    use_ssh_agent: bool = True
+
+    # ------------------------------------------------------------------ #
+    # Proxy jump                                                           #
+    # ------------------------------------------------------------------ #
+    # ProxyJump destination (e.g. "user@jumphost.example.com" or just
+    # the alias in ~/.ssh/config).  Leave empty for direct connections.
+    proxy_jump: str = ""
+
+    # ------------------------------------------------------------------ #
+    # Data sync                                                            #
+    # ------------------------------------------------------------------ #
+    auto_sync: bool = True
+    sync_interval: int = 30  # seconds between background poll cycles
+
+    # ------------------------------------------------------------------ #
+    # Convenience helpers                                                  #
+    # ------------------------------------------------------------------ #
+    def is_remote(self) -> bool:
+        """Return True when experiments run on a remote machine."""
+        return self.execution_mode.startswith("remote_")
+
+    def uses_slurm(self) -> bool:
+        """Return True when job submission goes through sbatch."""
+        return self.execution_mode.endswith("_slurm")
+
+    def to_dict(self) -> dict:
+        return asdict(self)
+
+    @classmethod
+    def from_dict(cls, data: dict) -> "RemoteSettings":
+        known = {f.name for f in dc_fields(cls)}
+        filtered = {k: v for k, v in data.items() if k in known}
+        instance = cls(**filtered)
+        if instance.execution_mode not in EXECUTION_MODES:
+            instance.execution_mode = "local_slurm"
+        return instance
+
+
+# --------------------------------------------------------------------------- #
+# Persistence                                                                  #
+# --------------------------------------------------------------------------- #
+
+def _settings_path(qd_root: str) -> str:
+    return os.path.join(os.path.expanduser(qd_root), SETTINGS_FILE)
+
+
+def load_remote_settings(qd_root: str) -> RemoteSettings:
+    """Load remote settings from disk.  Returns defaults if file is missing or corrupt."""
+    path = _settings_path(qd_root)
+    if not os.path.exists(path):
+        return RemoteSettings()
+    try:
+        with open(path, "r") as fh:
+            data = json.load(fh)
+        return RemoteSettings.from_dict(data)
+    except Exception:
+        return RemoteSettings()
+
+
+def save_remote_settings(settings: RemoteSettings, qd_root: str) -> None:
+    """Persist remote settings to disk (atomic write)."""
+    path = _settings_path(qd_root)
+    os.makedirs(os.path.dirname(path), exist_ok=True)
+    tmp = path + ".tmp"
+    with open(tmp, "w") as fh:
+        json.dump(settings.to_dict(), fh, indent=2)
+    os.replace(tmp, path)

--- a/qdashboard/remote/ssh_config.py
+++ b/qdashboard/remote/ssh_config.py
@@ -1,0 +1,143 @@
+"""
+SSH config file parser and raw editor helpers.
+
+Parses ``~/.ssh/config`` (or any OpenSSH client config) into structured
+``SSHHostEntry`` objects for display in the Settings UI.  Also provides
+read/write helpers for the raw file editor.
+"""
+
+import os
+import re
+from dataclasses import dataclass, field
+from typing import List, Optional
+
+
+@dataclass
+class SSHHostEntry:
+    """A single ``Host`` block parsed from an SSH config file."""
+
+    alias: str                           # The pattern after ``Host``
+    hostname: str = ""                   # HostName directive
+    user: str = ""                       # User directive
+    port: int = 22                       # Port directive (default 22)
+    identity_file: str = ""             # IdentityFile directive
+    proxy_jump: str = ""                 # ProxyJump directive
+    extra: dict = field(default_factory=dict)  # Any other directives
+
+    def to_dict(self) -> dict:
+        return {
+            "alias": self.alias,
+            "hostname": self.hostname,
+            "user": self.user,
+            "port": self.port,
+            "identity_file": self.identity_file,
+            "proxy_jump": self.proxy_jump,
+        }
+
+
+def parse_ssh_config(path: Optional[str] = None) -> List[SSHHostEntry]:
+    """Parse an SSH config file and return concrete (non-wildcard) host entries.
+
+    Args:
+        path: Path to the SSH config file.  Defaults to ``~/.ssh/config``.
+
+    Returns:
+        List of :class:`SSHHostEntry` objects, one per non-wildcard ``Host``
+        block found in the file.
+    """
+    if path is None:
+        path = os.path.expanduser("~/.ssh/config")
+    else:
+        path = os.path.expanduser(path)
+
+    if not os.path.exists(path):
+        return []
+
+    entries: List[SSHHostEntry] = []
+    current: Optional[SSHHostEntry] = None
+
+    with open(path, "r", errors="replace") as fh:
+        for raw_line in fh:
+            line = raw_line.strip()
+            if not line or line.startswith("#"):
+                continue
+
+            # Accept both "Key Value" and "Key=Value" (with optional spaces)
+            m = re.match(r"^(\w+)\s*[=\s]\s*(.+)$", line)
+            if not m:
+                continue
+
+            key = m.group(1).strip().lower()
+            value = m.group(2).strip()
+
+            if key == "host":
+                if current is not None and "*" not in current.alias:
+                    entries.append(current)
+                current = SSHHostEntry(alias=value)
+            elif current is not None:
+                if key == "hostname":
+                    current.hostname = value
+                elif key == "user":
+                    current.user = value
+                elif key == "port":
+                    try:
+                        current.port = int(value)
+                    except ValueError:
+                        pass
+                elif key == "identityfile":
+                    current.identity_file = value
+                elif key == "proxyjump":
+                    current.proxy_jump = value
+                else:
+                    current.extra[key] = value
+
+    if current is not None and "*" not in current.alias:
+        entries.append(current)
+
+    return entries
+
+
+def read_ssh_config_raw(path: Optional[str] = None) -> str:
+    """Return the raw text content of the SSH config file.
+
+    Returns an empty string if the file does not exist.
+    """
+    if path is None:
+        path = os.path.expanduser("~/.ssh/config")
+    else:
+        path = os.path.expanduser(path)
+
+    if not os.path.exists(path):
+        return ""
+    with open(path, "r", errors="replace") as fh:
+        return fh.read()
+
+
+def write_ssh_config_raw(content: str, path: Optional[str] = None) -> None:
+    """Write *content* to the SSH config file (atomic write with .bak backup).
+
+    Args:
+        content: New file content.
+        path: Destination path.  Defaults to ``~/.ssh/config``.
+
+    Raises:
+        OSError: If the file cannot be written.
+    """
+    if path is None:
+        path = os.path.expanduser("~/.ssh/config")
+    else:
+        path = os.path.expanduser(path)
+
+    ssh_dir = os.path.dirname(path)
+    os.makedirs(ssh_dir, exist_ok=True)
+
+    # Back up the existing file before overwriting
+    if os.path.exists(path):
+        backup = path + ".bak"
+        with open(path, "r", errors="replace") as src, open(backup, "w") as dst:
+            dst.write(src.read())
+
+    tmp = path + ".tmp"
+    with open(tmp, "w") as fh:
+        fh.write(content)
+    os.replace(tmp, path)

--- a/qdashboard/templates/_tab_settings.html
+++ b/qdashboard/templates/_tab_settings.html
@@ -1,0 +1,263 @@
+<!-- Settings Tab: Remote Execution Configuration -->
+<div class="settings-tab container-fluid py-3">
+
+    <!-- Header row with connection status -->
+    <div class="row mb-3">
+        <div class="col-12 d-flex align-items-center justify-content-between">
+            <h5 class="mb-0"><i class="fas fa-cog"></i> Execution Settings</h5>
+            <div id="settings-connection-status" class="d-flex align-items-center">
+                <span id="settings-conn-badge" class="badge badge-secondary mr-2">
+                    <i class="fas fa-circle mr-1"></i> Disconnected
+                </span>
+                <button class="btn btn-sm btn-outline-success mr-1" id="btn-ssh-connect" title="Connect SSH">
+                    <i class="fas fa-plug"></i> Connect
+                </button>
+                <button class="btn btn-sm btn-outline-danger" id="btn-ssh-disconnect" title="Disconnect SSH">
+                    <i class="fas fa-times"></i> Disconnect
+                </button>
+            </div>
+        </div>
+    </div>
+
+    <div class="row">
+
+        <!-- Left column: Execution mode + Remote server + Auth + ProxyJump -->
+        <div class="col-lg-6">
+
+            <!-- Execution Mode -->
+            <div class="card mb-3">
+                <div class="card-header">
+                    <i class="fas fa-play-circle"></i> Execution Mode
+                </div>
+                <div class="card-body">
+                    <div class="form-check mb-2">
+                        <input class="form-check-input" type="radio" name="executionMode"
+                               id="mode-local-slurm" value="local_slurm">
+                        <label class="form-check-label" for="mode-local-slurm">
+                            <strong>Local + SLURM</strong>
+                            <small class="d-block text-muted">Submit via sbatch on this machine (original mode)</small>
+                        </label>
+                    </div>
+                    <div class="form-check mb-2">
+                        <input class="form-check-input" type="radio" name="executionMode"
+                               id="mode-local-direct" value="local_direct">
+                        <label class="form-check-label" for="mode-local-direct">
+                            <strong>Local + Direct</strong>
+                            <small class="d-block text-muted">Run <code>qq run</code> directly on this machine (no sbatch)</small>
+                        </label>
+                    </div>
+                    <div class="form-check mb-2">
+                        <input class="form-check-input" type="radio" name="executionMode"
+                               id="mode-remote-slurm" value="remote_slurm">
+                        <label class="form-check-label" for="mode-remote-slurm">
+                            <strong>Remote + SLURM</strong>
+                            <small class="d-block text-muted">SSH to cluster, submit via sbatch there</small>
+                        </label>
+                    </div>
+                    <div class="form-check">
+                        <input class="form-check-input" type="radio" name="executionMode"
+                               id="mode-remote-direct" value="remote_direct">
+                        <label class="form-check-label" for="mode-remote-direct">
+                            <strong>Remote + Direct</strong>
+                            <small class="d-block text-muted">SSH to remote, run <code>qq run</code> directly there</small>
+                        </label>
+                    </div>
+                </div>
+            </div>
+
+            <!-- Remote Server (shown only for remote modes) -->
+            <div class="card mb-3" id="settings-remote-server-card">
+                <div class="card-header">
+                    <i class="fas fa-server"></i> Remote Server
+                </div>
+                <div class="card-body">
+                    <div class="form-row">
+                        <div class="form-group col-md-8">
+                            <label for="remote-host">Host / IP</label>
+                            <input type="text" class="form-control form-control-sm" id="remote-host"
+                                   placeholder="cluster.example.com">
+                        </div>
+                        <div class="form-group col-md-4">
+                            <label for="remote-port">Port</label>
+                            <input type="number" class="form-control form-control-sm" id="remote-port"
+                                   value="22" min="1" max="65535">
+                        </div>
+                    </div>
+                    <div class="form-group">
+                        <label for="remote-user">Username</label>
+                        <input type="text" class="form-control form-control-sm" id="remote-user"
+                               placeholder="your-username">
+                    </div>
+                    <div class="form-group">
+                        <label for="remote-root">Remote working root</label>
+                        <input type="text" class="form-control form-control-sm" id="remote-root"
+                               placeholder="~/.qdashboard">
+                        <small class="form-text text-muted">Base directory on the remote machine where experiments are stored.</small>
+                    </div>
+                    <div class="form-group mb-0">
+                        <label for="remote-environment">Remote Python environment path</label>
+                        <input type="text" class="form-control form-control-sm" id="remote-environment"
+                               placeholder="~/envs/qibocal  (leave blank to use active shell env)">
+                        <small class="form-text text-muted">venv or conda env containing <code>qq</code> / qibocal.</small>
+                    </div>
+                    <div class="form-group mt-2 mb-0">
+                        <label for="remote-platforms-path">Remote QIBOLAB_PLATFORMS path
+                            <small class="text-muted">(optional)</small>
+                        </label>
+                        <input type="text" class="form-control form-control-sm" id="remote-platforms-path"
+                               placeholder="~/qibolab_platforms_qrc  (leave blank to reuse local path)">
+                    </div>
+                </div>
+            </div>
+
+            <!-- SSH Authentication (shown only for remote modes) -->
+            <div class="card mb-3" id="settings-ssh-auth-card">
+                <div class="card-header">
+                    <i class="fas fa-key"></i> SSH Authentication
+                </div>
+                <div class="card-body">
+                    <div class="form-group">
+                        <label for="ssh-key-path">Private key file (local path)</label>
+                        <input type="text" class="form-control form-control-sm" id="ssh-key-path"
+                               placeholder="~/.ssh/id_rsa  (leave blank to use agent only)">
+                    </div>
+                    <div class="form-check mb-3">
+                        <input class="form-check-input" type="checkbox" id="use-ssh-agent" checked>
+                        <label class="form-check-label" for="use-ssh-agent">
+                            Use SSH agent (<code>ssh-agent</code> / pageant)
+                        </label>
+                    </div>
+                    <div class="form-group mb-0">
+                        <label for="proxy-jump">ProxyJump host</label>
+                        <div class="input-group input-group-sm">
+                            <input type="text" class="form-control" id="proxy-jump"
+                                   placeholder="user@jumphost.example.com  (leave blank for direct)">
+                            <div class="input-group-append">
+                                <button class="btn btn-outline-secondary" type="button"
+                                        id="btn-proxy-from-config" title="Pick from SSH config">
+                                    <i class="fas fa-list"></i>
+                                </button>
+                            </div>
+                        </div>
+                        <small class="form-text text-muted">Same syntax as OpenSSH <code>ProxyJump</code>.</small>
+                    </div>
+                </div>
+            </div>
+
+        </div>
+
+        <!-- Right column: Sync settings + SSH config editor -->
+        <div class="col-lg-6">
+
+            <!-- Sync Settings -->
+            <div class="card mb-3" id="settings-sync-card">
+                <div class="card-header d-flex justify-content-between align-items-center">
+                    <span><i class="fas fa-sync-alt"></i> Data Sync</span>
+                    <div id="settings-sync-status-badge"></div>
+                </div>
+                <div class="card-body">
+                    <div class="form-check mb-2">
+                        <input class="form-check-input" type="checkbox" id="auto-sync">
+                        <label class="form-check-label" for="auto-sync">
+                            Auto-sync completed experiments in background
+                        </label>
+                    </div>
+                    <div class="form-row align-items-center mb-3">
+                        <div class="col-auto">
+                            <label for="sync-interval" class="col-form-label col-form-label-sm">Poll interval</label>
+                        </div>
+                        <div class="col-auto">
+                            <input type="number" class="form-control form-control-sm" id="sync-interval"
+                                   value="30" min="5" max="3600" style="width:80px">
+                        </div>
+                        <div class="col-auto">
+                            <span class="text-muted small">seconds</span>
+                        </div>
+                    </div>
+                    <div class="d-flex">
+                        <button class="btn btn-sm btn-outline-primary mr-2" id="btn-sync-all">
+                            <i class="fas fa-cloud-download-alt"></i> Sync All Now
+                        </button>
+                        <span id="sync-all-result" class="small text-muted align-self-center"></span>
+                    </div>
+                </div>
+            </div>
+
+            <!-- SSH Config -->
+            <div class="card mb-3">
+                <div class="card-header">
+                    <i class="fas fa-file-code"></i> SSH Config (<code>~/.ssh/config</code>)
+                </div>
+                <div class="card-body p-0">
+                    <ul class="nav nav-tabs px-3 pt-2" id="ssh-config-tabs">
+                        <li class="nav-item">
+                            <a class="nav-link active" id="tab-known-hosts-link"
+                               data-toggle="tab" href="#tab-known-hosts">Known Hosts</a>
+                        </li>
+                        <li class="nav-item">
+                            <a class="nav-link" id="tab-ssh-editor-link"
+                               data-toggle="tab" href="#tab-ssh-editor">Editor</a>
+                        </li>
+                    </ul>
+                    <div class="tab-content p-3">
+
+                        <!-- Known Hosts tab -->
+                        <div class="tab-pane fade show active" id="tab-known-hosts">
+                            <div id="known-hosts-table-wrapper">
+                                <p class="text-muted small mb-2">
+                                    Click <em>Use</em> to populate the Remote Server fields with that entry.
+                                </p>
+                                <div class="table-responsive" style="max-height:260px;overflow-y:auto;">
+                                    <table class="table table-dark table-sm table-hover mb-0" id="known-hosts-table">
+                                        <thead>
+                                            <tr>
+                                                <th>Alias</th>
+                                                <th>Hostname</th>
+                                                <th>User</th>
+                                                <th>Port</th>
+                                                <th>ProxyJump</th>
+                                                <th></th>
+                                            </tr>
+                                        </thead>
+                                        <tbody id="known-hosts-tbody">
+                                            <tr><td colspan="6" class="text-center text-muted small">Loading…</td></tr>
+                                        </tbody>
+                                    </table>
+                                </div>
+                            </div>
+                        </div>
+
+                        <!-- Raw editor tab -->
+                        <div class="tab-pane fade" id="tab-ssh-editor">
+                            <textarea id="ssh-config-raw" class="form-control form-control-sm"
+                                      rows="12" style="font-family:monospace;font-size:12px;resize:vertical;"
+                                      placeholder="Loading ~/.ssh/config …"></textarea>
+                            <div class="mt-2 d-flex align-items-center">
+                                <button class="btn btn-sm btn-outline-warning mr-2" id="btn-save-ssh-config">
+                                    <i class="fas fa-save"></i> Save ~/.ssh/config
+                                </button>
+                                <small class="text-muted" id="ssh-config-save-result"></small>
+                            </div>
+                        </div>
+
+                    </div>
+                </div>
+            </div>
+
+        </div>
+    </div>
+
+    <!-- Save / Cancel row -->
+    <div class="row">
+        <div class="col-12 d-flex align-items-center">
+            <button class="btn btn-primary mr-2" id="btn-save-settings">
+                <i class="fas fa-save"></i> Save Settings
+            </button>
+            <button class="btn btn-secondary mr-3" id="btn-reload-settings">
+                <i class="fas fa-undo"></i> Reload
+            </button>
+            <span id="settings-save-result" class="small"></span>
+        </div>
+    </div>
+
+</div>

--- a/qdashboard/templates/_tab_settings.html
+++ b/qdashboard/templates/_tab_settings.html
@@ -105,7 +105,14 @@
                             <small class="text-muted">(optional)</small>
                         </label>
                         <input type="text" class="form-control form-control-sm" id="remote-platforms-path"
-                               placeholder="~/qibolab_platforms_qrc  (leave blank to reuse local path)">
+                               placeholder="~/qibolab_platforms_qrc  (blank = auto-detect)">
+                        <small class="form-text text-muted">
+                            Path to <code>qibolab_platforms_qrc</code> on the remote host. All platform git
+                            operations (branch switch, commit, stash, push) and edits run there — never
+                            locally. A read-only local mirror is kept in sync automatically for QPU
+                            monitoring/topology. Leave blank to auto-detect the remote's own
+                            <code>$QIBOLAB_PLATFORMS</code>, falling back to <code>~/qibolab_platforms_qrc</code>.
+                        </small>
                     </div>
                 </div>
             </div>

--- a/qdashboard/templates/_tab_slurm.html
+++ b/qdashboard/templates/_tab_slurm.html
@@ -1,13 +1,5 @@
 <div class="row">
     <div class="col-md-4">
-        <div class="card text-white bg-ibm-blue mb-3">
-            <div class="card-body">
-                <h5 class="card-title"><i class="fas fa-heartbeat"></i> QPU Health</h5>
-                <p class="card-text">{{ qpu_health }}</p>
-            </div>
-        </div>
-    </div>
-    <div class="col-md-4">
         <div class="card text-white bg-ibm-purple mb-3">
             <div class="card-body">
                 <h5 class="card-title"><i class="fas fa-microchip"></i> Available QPUs</h5>

--- a/qdashboard/templates/shell.html
+++ b/qdashboard/templates/shell.html
@@ -35,6 +35,8 @@ Action Card Builder, and on-demand Latest-experiment-Viewer report tabs).
                         <i class="fas fa-microchip"></i><span class="menu-text"> QPU Status</span></a>
                     <a href="#" class="list-group-item list-group-item-action" id="activity-latest-report" data-open-latest-report title="Latest Report">
                         <i class="fas fa-file-alt"></i><span class="menu-text"> Latest Report</span></a>
+                    <a href="#" class="list-group-item list-group-item-action mt-auto" id="activity-settings" data-open-tab="settings" title="Settings">
+                        <i class="fas fa-cog"></i><span class="menu-text"> Settings</span></a>
                 </div>
             </div>
         </div>
@@ -72,6 +74,9 @@ Action Card Builder, and on-demand Latest-experiment-Viewer report tabs).
                 </div>
                 <div id="tab-pane-action_builder" class="qd-tabpane">
                     {% include '_tab_action_builder.html' %}
+                </div>
+                <div id="tab-pane-settings" class="qd-tabpane container-fluid py-3">
+                    {% include '_tab_settings.html' %}
                 </div>
                 <!-- Latest-Viewer report tabs (iframe) are created/removed dynamically here -->
             </div>
@@ -128,6 +133,7 @@ Action Card Builder, and on-demand Latest-experiment-Viewer report tabs).
     <script src="{{url_for('assets', path='js/history-panel.js')}}"></script>
     <script src="{{url_for('assets', path='js/explorer-panel.js')}}"></script>
     <script src="{{url_for('assets', path='js/experiment-builder.js')}}"></script>
+    <script src="{{url_for('assets', path='js/settings-panel.js')}}"></script>
     <script src="{{url_for('assets', path='js/shell.js')}}"></script>
 </body>
 </html>

--- a/qdashboard/web/routes.py
+++ b/qdashboard/web/routes.py
@@ -16,7 +16,7 @@ from fastapi import APIRouter, Request, Form, File, UploadFile, Query, HTTPExcep
 from fastapi.responses import FileResponse, Response, StreamingResponse, RedirectResponse
 from starlette.responses import HTMLResponse
 
-from ..qpu.monitoring import get_qpu_health, get_available_qpus, get_qibo_versions, get_qpu_details, get_qpu_list, qpu_parameters
+from ..qpu.monitoring import get_available_qpus, get_qibo_versions, get_qpu_details, get_qpu_list, qpu_parameters
 from ..qpu.platforms import get_platforms_path, list_repository_branches, switch_repository_branch, get_current_branch_info, commit_changes, generate_commit_message, push_changes, stash_changes, list_stashes, apply_latest_stash, discard_changes, get_partition
 from ..remote import platforms_git as remote_platforms_git
 from ..qpu.slurm import get_slurm_status, get_slurm_output
@@ -176,7 +176,6 @@ async def shell(request: Request):
     version_data = get_qibo_versions(request=request)
 
     # Slurm Monitor tab
-    qpu_health = get_qpu_health()
     available_qpus = get_available_qpus()
     slurm_queue_status = get_slurm_status()
     last_slurm_log = get_slurm_output()
@@ -229,7 +228,6 @@ async def shell(request: Request):
         request=request,
         qibo_versions=version_data['versions'],
         # Slurm Monitor
-        qpu_health=qpu_health,
         available_qpus=available_qpus,
         slurm_queue_status=slurm_queue_status,
         last_slurm_log=last_slurm_log,

--- a/qdashboard/web/routes.py
+++ b/qdashboard/web/routes.py
@@ -18,6 +18,7 @@ from starlette.responses import HTMLResponse
 
 from ..qpu.monitoring import get_qpu_health, get_available_qpus, get_qibo_versions, get_qpu_details, get_qpu_list, qpu_parameters
 from ..qpu.platforms import get_platforms_path, list_repository_branches, switch_repository_branch, get_current_branch_info, commit_changes, generate_commit_message, push_changes, stash_changes, list_stashes, apply_latest_stash, discard_changes, get_partition
+from ..remote import platforms_git as remote_platforms_git
 from ..qpu.slurm import get_slurm_status, get_slurm_output
 from ..qpu.topology import qpu_connectivity, infer_topology_from_connectivity, generate_topology_visualization
 from ..experiments.protocols import get_qibocal_protocols, get_protocol_attributes
@@ -36,6 +37,36 @@ router = APIRouter()
 def _get_config(request: Request) -> dict:
     """Helper to retrieve config from app state."""
     return request.app.state.config
+
+
+async def _remote_platforms_context(request: Request):
+    """Resolve the remote SSH connection + platforms path for platform
+    git/file operations, when the current execution mode is remote.
+
+    Returns:
+        ``None`` if execution mode is local — callers should use the local
+        ``qpu.platforms``/``get_platforms_path()`` path as before.
+        ``"not_connected"`` if remote mode is configured but not connected —
+        callers should return a 409 rather than silently falling back to
+        local git/file operations (all platform git operations must happen
+        on the remote host).
+        ``(ssh_manager, remote_path)`` if remote mode and connected.
+    """
+    settings = _get_remote_settings(request)
+    if not settings.is_remote():
+        return None
+    ssh_manager = request.app.state.ssh_manager
+    if not ssh_manager.is_connected():
+        return "not_connected"
+    remote_path = await remote_platforms_git.resolve_remote_platforms_path(settings, ssh_manager)
+    return ssh_manager, remote_path
+
+
+def _not_connected_response():
+    return Response(
+        content=json.dumps({'error': 'Not connected to remote host. Connect in Settings first.'}),
+        status_code=409, media_type='application/json',
+    )
 
 
 def _no_cache_headers() -> dict:
@@ -154,8 +185,17 @@ async def shell(request: Request):
     config = _get_config(request)
     qpu_details = get_qpu_details()
     platforms_path = get_platforms_path(config['root'])
-    git_branches_info = list_repository_branches(platforms_path) if platforms_path else None
-    git_current_branch_info = get_current_branch_info(platforms_path) if platforms_path else None
+    remote_ctx = await _remote_platforms_context(request)
+    if isinstance(remote_ctx, tuple):
+        ssh_manager, remote_path = remote_ctx
+        git_branches_info = await remote_platforms_git.list_repository_branches(ssh_manager, remote_path)
+        git_current_branch_info = await remote_platforms_git.get_current_branch_info(ssh_manager, remote_path)
+    elif remote_ctx == "not_connected":
+        git_branches_info = None
+        git_current_branch_info = None
+    else:
+        git_branches_info = list_repository_branches(platforms_path) if platforms_path else None
+        git_current_branch_info = get_current_branch_info(platforms_path) if platforms_path else None
 
     # Action Card Builder tab + Experiment Library panel
     protocols = get_qibocal_protocols()
@@ -372,17 +412,71 @@ async def qpus(request: Request):
     return RedirectResponse(url="/?open=qpu_status", status_code=307)
 
 
+def _platforms_mirror_dir(request: Request) -> str:
+    from ..core.config import get_qd_root
+    return os.path.join(get_qd_root(), 'platforms_mirror')
+
+
+async def _refresh_platforms_mirror(request: Request, ssh_manager) -> None:
+    """Best-effort mirror refresh after a mutating remote git op."""
+    try:
+        settings = _get_remote_settings(request)
+        await remote_platforms_git.sync_platforms_mirror(settings, ssh_manager, _platforms_mirror_dir(request))
+    except Exception as exc:
+        logger.warning("Failed to refresh platforms mirror: %s", exc)
+
+
+async def _write_platform_file(request: Request, relative_path: str, content: str):
+    """Write *content* to ``<platforms_dir>/relative_path``.
+
+    In remote mode this writes straight to the actual remote file via SFTP
+    (never the local read-only mirror, which would silently discard the edit
+    on the next sync) and refreshes the mirror afterwards. In local mode it's
+    an atomic local write, same as before.
+
+    Returns ``(True, None)`` on success, or ``(False, error_message)``.
+    """
+    remote_ctx = await _remote_platforms_context(request)
+    if remote_ctx == "not_connected":
+        return False, 'Not connected to remote host. Connect in Settings first.'
+    if isinstance(remote_ctx, tuple):
+        ssh_manager, remote_path = remote_ctx
+        await remote_platforms_git.write_remote_file(ssh_manager, remote_path, relative_path, content)
+        await _refresh_platforms_mirror(request, ssh_manager)
+        return True, None
+
+    config = _get_config(request)
+    platforms_path = get_platforms_path(config.get('root', ''))
+    if not platforms_path:
+        return False, 'Platforms directory not configured'
+    full_path = _safe_path_join(platforms_path, relative_path)
+    if full_path is None:
+        return False, 'Invalid platform path'
+    tmp_path = full_path + '.tmp'
+    with open(tmp_path, 'w') as f:
+        f.write(content)
+    os.replace(tmp_path, full_path)
+    return True, None
+
+
 @router.get("/api/platforms/branches", name="api_platforms_branches", tags=["Platforms"],
             summary="List all branches in the platforms repository")
 async def api_platforms_branches(request: Request):
     """API endpoint to get available branches."""
     try:
-        config = _get_config(request)
-        platforms_path = get_platforms_path(config['root'])
-        if not platforms_path:
-            return Response(content=json.dumps({'error': 'Platforms directory not available'}),
-                            status_code=404, media_type='application/json')
-        branches_info = list_repository_branches(platforms_path)
+        remote_ctx = await _remote_platforms_context(request)
+        if remote_ctx == "not_connected":
+            return _not_connected_response()
+        if isinstance(remote_ctx, tuple):
+            ssh_manager, remote_path = remote_ctx
+            branches_info = await remote_platforms_git.list_repository_branches(ssh_manager, remote_path)
+        else:
+            config = _get_config(request)
+            platforms_path = get_platforms_path(config['root'])
+            if not platforms_path:
+                return Response(content=json.dumps({'error': 'Platforms directory not available'}),
+                                status_code=404, media_type='application/json')
+            branches_info = list_repository_branches(platforms_path)
         if not branches_info:
             return Response(content=json.dumps({'error': 'Failed to retrieve branch information'}),
                             status_code=500, media_type='application/json')
@@ -396,7 +490,6 @@ async def api_platforms_branches(request: Request):
 async def api_platforms_switch(request: Request):
     """API endpoint to switch platform branch."""
     try:
-        config = _get_config(request)
         data = await request.json()
         if not data or 'branch' not in data:
             return Response(content=json.dumps({'error': 'Branch name is required'}),
@@ -404,11 +497,22 @@ async def api_platforms_switch(request: Request):
         branch_name = data['branch']
         create_if_not_exists = data.get('create', False)
         handle_changes = data.get('handle_changes', 'fail')
-        platforms_path = get_platforms_path(config['root'])
-        if not platforms_path:
-            return Response(content=json.dumps({'error': 'Platforms directory not available'}),
-                            status_code=404, media_type='application/json')
-        switch_result = switch_repository_branch(platforms_path, branch_name, create_if_not_exists, handle_changes)
+
+        remote_ctx = await _remote_platforms_context(request)
+        if remote_ctx == "not_connected":
+            return _not_connected_response()
+        if isinstance(remote_ctx, tuple):
+            ssh_manager, platforms_path = remote_ctx
+            switch_result = await remote_platforms_git.switch_repository_branch(
+                ssh_manager, platforms_path, branch_name, create_if_not_exists, handle_changes)
+        else:
+            config = _get_config(request)
+            platforms_path = get_platforms_path(config['root'])
+            if not platforms_path:
+                return Response(content=json.dumps({'error': 'Platforms directory not available'}),
+                                status_code=404, media_type='application/json')
+            switch_result = switch_repository_branch(platforms_path, branch_name, create_if_not_exists, handle_changes)
+
         if not switch_result['success']:
             return Response(
                 content=json.dumps({
@@ -416,7 +520,13 @@ async def api_platforms_switch(request: Request):
                     'has_changes': switch_result.get('has_changes', False),
                 }),
                 status_code=400, media_type='application/json')
-        current_branch_info = get_current_branch_info(platforms_path)
+
+        if isinstance(remote_ctx, tuple):
+            ssh_manager, platforms_path = remote_ctx
+            current_branch_info = await remote_platforms_git.get_current_branch_info(ssh_manager, platforms_path)
+            await _refresh_platforms_mirror(request, ssh_manager)
+        else:
+            current_branch_info = get_current_branch_info(platforms_path)
         qpu_details = get_qpu_details()
         response_data = {
             'success': True, 'branch': branch_name,
@@ -440,12 +550,19 @@ async def api_platforms_switch(request: Request):
 async def api_platforms_current(request: Request):
     """API endpoint to get current branch information."""
     try:
-        config = _get_config(request)
-        platforms_path = get_platforms_path(config['root'])
-        if not platforms_path:
-            return Response(content=json.dumps({'error': 'Platforms directory not available'}),
-                            status_code=404, media_type='application/json')
-        current_branch_info = get_current_branch_info(platforms_path)
+        remote_ctx = await _remote_platforms_context(request)
+        if remote_ctx == "not_connected":
+            return _not_connected_response()
+        if isinstance(remote_ctx, tuple):
+            ssh_manager, platforms_path = remote_ctx
+            current_branch_info = await remote_platforms_git.get_current_branch_info(ssh_manager, platforms_path)
+        else:
+            config = _get_config(request)
+            platforms_path = get_platforms_path(config['root'])
+            if not platforms_path:
+                return Response(content=json.dumps({'error': 'Platforms directory not available'}),
+                                status_code=404, media_type='application/json')
+            current_branch_info = get_current_branch_info(platforms_path)
         if not current_branch_info:
             return Response(content=json.dumps({'error': 'Failed to get current branch information'}),
                             status_code=500, media_type='application/json')
@@ -460,12 +577,20 @@ async def api_platforms_commit_message(request: Request):
     """API endpoint to preview the commit message that would be used for the
     currently pending (uncommitted) changes, without committing anything."""
     try:
-        config = _get_config(request)
-        platforms_path = get_platforms_path(config['root'])
-        if not platforms_path:
-            return Response(content=json.dumps({'error': 'Platforms directory not available'}),
-                            status_code=404, media_type='application/json')
-        return {'message': generate_commit_message(platforms_path)}
+        remote_ctx = await _remote_platforms_context(request)
+        if remote_ctx == "not_connected":
+            return _not_connected_response()
+        if isinstance(remote_ctx, tuple):
+            ssh_manager, platforms_path = remote_ctx
+            message = await remote_platforms_git.generate_commit_message(ssh_manager, platforms_path)
+        else:
+            config = _get_config(request)
+            platforms_path = get_platforms_path(config['root'])
+            if not platforms_path:
+                return Response(content=json.dumps({'error': 'Platforms directory not available'}),
+                                status_code=404, media_type='application/json')
+            message = generate_commit_message(platforms_path)
+        return {'message': message}
     except Exception as e:
         return _error_response(request, e)
 
@@ -475,17 +600,28 @@ async def api_platforms_commit_message(request: Request):
 async def api_platforms_commit(request: Request):
     """API endpoint to commit changes to the platforms repository."""
     try:
-        config = _get_config(request)
-        platforms_path = get_platforms_path(config['root'])
-        if not platforms_path:
-            return Response(content=json.dumps({'error': 'Platforms directory not available'}),
-                            status_code=404, media_type='application/json')
         data = await request.json() if request.headers.get('content-type', '').startswith('application/json') else {}
         commit_message = data.get('message')
-        result = commit_changes(platforms_path, commit_message)
+
+        remote_ctx = await _remote_platforms_context(request)
+        if remote_ctx == "not_connected":
+            return _not_connected_response()
+        if isinstance(remote_ctx, tuple):
+            ssh_manager, platforms_path = remote_ctx
+            result = await remote_platforms_git.commit_changes(ssh_manager, platforms_path, commit_message)
+        else:
+            config = _get_config(request)
+            platforms_path = get_platforms_path(config['root'])
+            if not platforms_path:
+                return Response(content=json.dumps({'error': 'Platforms directory not available'}),
+                                status_code=404, media_type='application/json')
+            result = commit_changes(platforms_path, commit_message)
+
         if not result['success']:
             return Response(content=json.dumps({'error': result.get('error', 'Commit failed')}),
                             status_code=400, media_type='application/json')
+        if isinstance(remote_ctx, tuple):
+            await _refresh_platforms_mirror(request, remote_ctx[0])
         return result
     except Exception as e:
         return _error_response(request, e)
@@ -496,17 +632,28 @@ async def api_platforms_commit(request: Request):
 async def api_platforms_stash(request: Request):
     """API endpoint to stash changes in the platforms repository."""
     try:
-        config = _get_config(request)
-        platforms_path = get_platforms_path(config['root'])
-        if not platforms_path:
-            return Response(content=json.dumps({'error': 'Platforms directory not available'}),
-                            status_code=404, media_type='application/json')
         data = await request.json() if request.headers.get('content-type', '').startswith('application/json') else {}
         stash_message = data.get('message', 'WIP: Stashed via QDashboard')
-        result = stash_changes(platforms_path, stash_message)
+
+        remote_ctx = await _remote_platforms_context(request)
+        if remote_ctx == "not_connected":
+            return _not_connected_response()
+        if isinstance(remote_ctx, tuple):
+            ssh_manager, platforms_path = remote_ctx
+            result = await remote_platforms_git.stash_changes(ssh_manager, platforms_path, stash_message)
+        else:
+            config = _get_config(request)
+            platforms_path = get_platforms_path(config['root'])
+            if not platforms_path:
+                return Response(content=json.dumps({'error': 'Platforms directory not available'}),
+                                status_code=404, media_type='application/json')
+            result = stash_changes(platforms_path, stash_message)
+
         if not result['success']:
             return Response(content=json.dumps({'error': result.get('error', 'Stash failed')}),
                             status_code=400, media_type='application/json')
+        if isinstance(remote_ctx, tuple):
+            await _refresh_platforms_mirror(request, remote_ctx[0])
         return result
     except Exception as e:
         return _error_response(request, e)
@@ -517,15 +664,25 @@ async def api_platforms_stash(request: Request):
 async def api_platforms_discard(request: Request):
     """API endpoint to discard all uncommitted changes."""
     try:
-        config = _get_config(request)
-        platforms_path = get_platforms_path(config['root'])
-        if not platforms_path:
-            return Response(content=json.dumps({'error': 'Platforms directory not available'}),
-                            status_code=404, media_type='application/json')
-        result = discard_changes(platforms_path)
+        remote_ctx = await _remote_platforms_context(request)
+        if remote_ctx == "not_connected":
+            return _not_connected_response()
+        if isinstance(remote_ctx, tuple):
+            ssh_manager, platforms_path = remote_ctx
+            result = await remote_platforms_git.discard_changes(ssh_manager, platforms_path)
+        else:
+            config = _get_config(request)
+            platforms_path = get_platforms_path(config['root'])
+            if not platforms_path:
+                return Response(content=json.dumps({'error': 'Platforms directory not available'}),
+                                status_code=404, media_type='application/json')
+            result = discard_changes(platforms_path)
+
         if not result['success']:
             return Response(content=json.dumps({'error': result.get('error', 'Discard failed')}),
                             status_code=400, media_type='application/json')
+        if isinstance(remote_ctx, tuple):
+            await _refresh_platforms_mirror(request, remote_ctx[0])
         return result
     except Exception as e:
         return _error_response(request, e)
@@ -536,12 +693,20 @@ async def api_platforms_discard(request: Request):
 async def api_platforms_list_stashes(request: Request):
     """API endpoint to list all stashes."""
     try:
-        config = _get_config(request)
-        platforms_path = get_platforms_path(config['root'])
-        if not platforms_path:
-            return Response(content=json.dumps({'error': 'Platforms directory not available'}),
-                            status_code=404, media_type='application/json')
-        result = list_stashes(platforms_path)
+        remote_ctx = await _remote_platforms_context(request)
+        if remote_ctx == "not_connected":
+            return _not_connected_response()
+        if isinstance(remote_ctx, tuple):
+            ssh_manager, platforms_path = remote_ctx
+            result = await remote_platforms_git.list_stashes(ssh_manager, platforms_path)
+        else:
+            config = _get_config(request)
+            platforms_path = get_platforms_path(config['root'])
+            if not platforms_path:
+                return Response(content=json.dumps({'error': 'Platforms directory not available'}),
+                                status_code=404, media_type='application/json')
+            result = list_stashes(platforms_path)
+
         if not result['success']:
             return Response(content=json.dumps({'error': result.get('error', 'Failed to list stashes')}),
                             status_code=400, media_type='application/json')
@@ -555,12 +720,19 @@ async def api_platforms_list_stashes(request: Request):
 async def api_platforms_push(request: Request):
     """API endpoint to push changes to the remote repository."""
     try:
-        config = _get_config(request)
-        platforms_path = get_platforms_path(config['root'])
-        if not platforms_path:
-            return Response(content=json.dumps({'error': 'Platforms directory not available'}),
-                            status_code=404, media_type='application/json')
-        result = push_changes(platforms_path)
+        remote_ctx = await _remote_platforms_context(request)
+        if remote_ctx == "not_connected":
+            return _not_connected_response()
+        if isinstance(remote_ctx, tuple):
+            ssh_manager, platforms_path = remote_ctx
+            result = await remote_platforms_git.push_changes(ssh_manager, platforms_path)
+        else:
+            config = _get_config(request)
+            platforms_path = get_platforms_path(config['root'])
+            if not platforms_path:
+                return Response(content=json.dumps({'error': 'Platforms directory not available'}),
+                                status_code=404, media_type='application/json')
+            result = push_changes(platforms_path)
         if not result['success']:
             return Response(content=json.dumps({'error': result.get('error', 'Push failed')}),
                             status_code=400, media_type='application/json')
@@ -762,8 +934,10 @@ async def api_action_nodes_save(request: Request, platform: str):
 
         nodes = _load_action_nodes(path)
         nodes[node_name] = {'action_card': action_card}
-        with open(path, 'w') as f:
-            json.dump(nodes, f, indent=2)
+        ok, err = await _write_platform_file(request, f"{platform}/action_nodes.json", json.dumps(nodes, indent=2))
+        if not ok:
+            return Response(content=json.dumps({'success': False, 'error': err}),
+                            status_code=409, media_type='application/json')
         return {'success': True, 'nodes': nodes}
     except Exception as e:
         return _error_response(request, e, {'success': False, 'error': str(e)})
@@ -784,8 +958,10 @@ async def api_action_nodes_delete(request: Request, platform: str, node_name: st
             return Response(content=json.dumps({'success': False, 'error': 'Action node not found'}),
                             status_code=404, media_type='application/json')
         del nodes[node_name]
-        with open(path, 'w') as f:
-            json.dump(nodes, f, indent=2)
+        ok, err = await _write_platform_file(request, f"{platform}/action_nodes.json", json.dumps(nodes, indent=2))
+        if not ok:
+            return Response(content=json.dumps({'success': False, 'error': err}),
+                            status_code=409, media_type='application/json')
         return {'success': True, 'nodes': nodes}
     except Exception as e:
         return _error_response(request, e, {'success': False, 'error': str(e)})
@@ -1079,11 +1255,11 @@ async def qpu_parameters_file_put(request: Request, platform: str):
         except Exception:
             return Response(content=json.dumps({'success': False, 'message': 'Invalid JSON body'}),
                             status_code=400, media_type='application/json')
-        # Atomic write via temp file
-        tmp_path = params_file + '.tmp'
-        with open(tmp_path, 'w') as f:
-            json.dump(new_data, f, indent=2)
-        os.replace(tmp_path, params_file)
+        ok, err = await _write_platform_file(
+            request, f"{platform}/parameters.json", json.dumps(new_data, indent=2))
+        if not ok:
+            return Response(content=json.dumps({'success': False, 'message': err}),
+                            status_code=409, media_type='application/json')
         logger.info(f"Updated parameters.json for platform '{platform}'")
         return {'success': True, 'message': 'Parameters saved successfully'}
     except Exception as e:
@@ -1317,6 +1493,10 @@ async def remote_connect_route(request: Request):
             return {'success': False, 'message': 'No remote host configured.'}
         ssh_manager = request.app.state.ssh_manager
         await ssh_manager.connect(settings)
+        # Populate the local platforms mirror immediately so QPU Status /
+        # topology / partition lookups don't wait for the next background
+        # poll tick. Best-effort — a failed sync here shouldn't fail connect.
+        await _refresh_platforms_mirror(request, ssh_manager)
         return {'success': True, 'message': f'Connected to {settings.remote_host}',
                 **ssh_manager.status_dict()}
     except Exception as e:

--- a/qdashboard/web/routes.py
+++ b/qdashboard/web/routes.py
@@ -902,9 +902,9 @@ async def submit_experiment_route(request: Request,
 
 
 @router.post("/api/submit_experiment_data", name="submit_experiment_data_route", tags=["Experiments"],
-             summary="Submit a new experiment to SLURM using a JSON runcard payload")
+             summary="Submit a new experiment using a JSON runcard payload")
 async def submit_experiment_data_route(request: Request):
-    """Submit a new experiment to SLURM using runcard data (JSON body)."""
+    """Submit a new experiment; routes to remote/direct/local-SLURM based on current settings."""
     try:
         config = _get_config(request)
         if not request.headers.get('content-type', '').startswith('application/json'):
@@ -926,10 +926,36 @@ async def submit_experiment_data_route(request: Request):
             return Response(content=json.dumps({'success': False,
                             'message': 'Missing required field: platform'}),
                             status_code=400, media_type='application/json')
-        result = submit_experiment(runcard_data=runcard_data, config=config, environment=environment,
-                                   auto_update=auto_update)
+
+        # Route to the appropriate execution path based on settings
+        from ..core.config import get_remote_settings
+        settings = get_remote_settings()
+
+        if settings.is_remote():
+            from ..experiments.job_submission import submit_experiment_remote
+            result = await submit_experiment_remote(
+                runcard_data=runcard_data,
+                config=config,
+                settings=settings,
+                ssh_manager=request.app.state.ssh_manager,
+                environment=environment,
+                auto_update=auto_update,
+            )
+        elif settings.execution_mode == 'local_direct':
+            from ..experiments.job_submission import submit_experiment_direct
+            result = submit_experiment_direct(
+                runcard_data=runcard_data,
+                config=config,
+                environment=environment,
+                auto_update=auto_update,
+            )
+        else:
+            # Default: local_slurm (existing behaviour)
+            result = submit_experiment(runcard_data=runcard_data, config=config,
+                                       environment=environment, auto_update=auto_update)
+
         if result['success']:
-            logger.info(f"New experiment submitted with data: {result['experiment_id']}")
+            logger.info(f"Experiment submitted ({settings.execution_mode}): {result['experiment_id']}")
             return _sanitize_exp(result)
         return Response(content=json.dumps(_sanitize_exp(result)), status_code=400,
                         media_type='application/json')
@@ -1202,6 +1228,218 @@ def _extract_traceback(text: str, re_mod) -> dict:
                 'error_message': m.group(2).strip(),
                 'traceback': f'{m.group(1)}: {m.group(2).strip()}'}
     return {'found': False, 'error_type': '', 'error_message': '', 'traceback': ''}
+
+
+# =========================================================================== #
+# Settings API                                                                 #
+# =========================================================================== #
+
+def _get_remote_settings(request: Request):
+    """Load remote settings using the qd_root from app config."""
+    from ..remote.settings import load_remote_settings
+    qd_root = _get_config(request).get('qd_root', '~/.qdashboard')
+    return load_remote_settings(qd_root)
+
+
+def _save_remote_settings(request: Request, settings):
+    """Persist remote settings using qd_root from app config."""
+    from ..remote.settings import save_remote_settings
+    qd_root = _get_config(request).get('qd_root', '~/.qdashboard')
+    save_remote_settings(settings, qd_root)
+
+
+@router.get("/api/settings/remote", tags=["Settings"],
+            summary="Get remote execution settings")
+async def get_remote_settings_route(request: Request):
+    """Return the current remote execution settings as JSON."""
+    try:
+        settings = _get_remote_settings(request)
+        return settings.to_dict()
+    except Exception as e:
+        return _error_response(request, e)
+
+
+@router.put("/api/settings/remote", tags=["Settings"],
+            summary="Update remote execution settings")
+async def put_remote_settings_route(request: Request):
+    """Save remote execution settings.  Returns the updated settings dict."""
+    try:
+        from ..remote.settings import RemoteSettings, EXECUTION_MODES
+        data = await request.json()
+        settings = RemoteSettings.from_dict(data)
+        _save_remote_settings(request, settings)
+        logger.info("Remote settings updated: execution_mode=%s", settings.execution_mode)
+        return settings.to_dict()
+    except Exception as e:
+        return _error_response(request, e)
+
+
+@router.get("/api/settings/ssh_config", tags=["Settings"],
+            summary="Get parsed SSH config hosts and raw file content")
+async def get_ssh_config_route(request: Request):
+    """Return parsed Host entries and raw content from ``~/.ssh/config``."""
+    try:
+        from ..remote.ssh_config import parse_ssh_config, read_ssh_config_raw
+        entries = [e.to_dict() for e in parse_ssh_config()]
+        raw = read_ssh_config_raw()
+        return {'entries': entries, 'raw': raw}
+    except Exception as e:
+        return _error_response(request, e)
+
+
+@router.put("/api/settings/ssh_config", tags=["Settings"],
+            summary="Write raw content to ~/.ssh/config")
+async def put_ssh_config_route(request: Request):
+    """Overwrite ``~/.ssh/config`` with the supplied content (backup created)."""
+    try:
+        from ..remote.ssh_config import write_ssh_config_raw
+        data = await request.json()
+        content = data.get('content', '')
+        write_ssh_config_raw(content)
+        return {'success': True, 'message': 'SSH config saved (backup written to ~/.ssh/config.bak)'}
+    except Exception as e:
+        return _error_response(request, e)
+
+
+# =========================================================================== #
+# Remote connection API                                                        #
+# =========================================================================== #
+
+@router.post("/api/remote/connect", tags=["Remote"],
+             summary="Open SSH connection to the remote host")
+async def remote_connect_route(request: Request):
+    """Connect to the remote host defined in the current settings."""
+    try:
+        settings = _get_remote_settings(request)
+        if not settings.is_remote():
+            return {'success': False, 'message': 'Current execution mode is not remote.'}
+        if not settings.remote_host:
+            return {'success': False, 'message': 'No remote host configured.'}
+        ssh_manager = request.app.state.ssh_manager
+        await ssh_manager.connect(settings)
+        return {'success': True, 'message': f'Connected to {settings.remote_host}',
+                **ssh_manager.status_dict()}
+    except Exception as e:
+        return _error_response(request, e, {'success': False, 'message': str(e)})
+
+
+@router.post("/api/remote/disconnect", tags=["Remote"],
+             summary="Close the SSH connection")
+async def remote_disconnect_route(request: Request):
+    """Disconnect from the remote host."""
+    try:
+        ssh_manager = request.app.state.ssh_manager
+        await ssh_manager.disconnect()
+        return {'success': True, 'message': 'Disconnected.'}
+    except Exception as e:
+        return _error_response(request, e)
+
+
+@router.get("/api/remote/status", tags=["Remote"],
+            summary="Get SSH connection status")
+async def remote_status_route(request: Request):
+    """Return connection status and settings summary."""
+    try:
+        ssh_manager = request.app.state.ssh_manager
+        settings = _get_remote_settings(request)
+        return {
+            **ssh_manager.status_dict(),
+            'execution_mode': settings.execution_mode,
+            'auto_sync': settings.auto_sync,
+            'sync_interval': settings.sync_interval,
+        }
+    except Exception as e:
+        return _error_response(request, e)
+
+
+# =========================================================================== #
+# Data sync API                                                                #
+# =========================================================================== #
+
+@router.post("/api/remote/sync/{experiment_id}", tags=["Remote"],
+             summary="Sync a single experiment from the remote to local storage")
+async def remote_sync_experiment(request: Request, experiment_id: str):
+    """Pull output/, runcard.yml, and metadata for *experiment_id* from remote."""
+    try:
+        from ..remote.file_sync import sync_experiment_from_remote
+        config = _get_config(request)
+        settings = _get_remote_settings(request)
+        ssh_manager = request.app.state.ssh_manager
+        data_dir = config.get('data_dir', '')
+
+        if not ssh_manager.is_connected():
+            return {'success': False, 'message': 'Not connected to remote host.'}
+
+        # Resolve platform/date from local DB or experiment_id prefix
+        platform = ''
+        date_str = experiment_id.split('-')[0] if '-' in experiment_id else ''
+        try:
+            from ..db.database import get_db_connection, query_runs
+            with get_db_connection(config) as conn:
+                rows = query_runs(conn, limit=1000)
+                for row in rows:
+                    if row.get('experiment_id') == experiment_id:
+                        platform = row.get('qpu_name') or row.get('platform') or ''
+                        break
+        except Exception:
+            pass
+
+        if not platform or not date_str:
+            return {'success': False, 'message': 'Cannot determine platform/date for this experiment.'}
+
+        files = await sync_experiment_from_remote(
+            experiment_id, platform, date_str, settings, ssh_manager, data_dir
+        )
+        return {'success': True, 'files_synced': len(files), 'experiment_id': experiment_id}
+    except Exception as e:
+        return _error_response(request, e)
+
+
+@router.post("/api/remote/sync_all", tags=["Remote"],
+             summary="Sync all completed remote experiments to local storage")
+async def remote_sync_all(request: Request):
+    """Scan the remote data directory and pull any completed experiments."""
+    try:
+        from ..remote.file_sync import sync_all_completed
+        config = _get_config(request)
+        settings = _get_remote_settings(request)
+        ssh_manager = request.app.state.ssh_manager
+        data_dir = config.get('data_dir', '')
+
+        if not ssh_manager.is_connected():
+            return {'success': False, 'message': 'Not connected to remote host.'}
+
+        result = await sync_all_completed(settings, ssh_manager, data_dir)
+        return {'success': True, **result}
+    except Exception as e:
+        return _error_response(request, e)
+
+
+@router.get("/api/remote/sync_status", tags=["Remote"],
+            summary="Get sync status summary")
+async def remote_sync_status(request: Request):
+    """Return count of pending experiments awaiting sync and connection status."""
+    try:
+        config = _get_config(request)
+        settings = _get_remote_settings(request)
+        ssh_manager = request.app.state.ssh_manager
+        pending_count = 0
+        try:
+            from ..db.database import get_db_connection, query_runs, count_runs
+            with get_db_connection(config) as conn:
+                pending_count = count_runs(conn, status=['pending', 'running'])
+        except Exception:
+            pass
+        return {
+            'connected': ssh_manager.is_connected(),
+            'execution_mode': settings.execution_mode,
+            'pending_experiments': pending_count,
+            'auto_sync': settings.auto_sync,
+            'sync_interval': settings.sync_interval,
+        }
+    except Exception as e:
+        return _error_response(request, e)
+
 
 
 @router.get("/api/experiment_log/{experiment_id}", name="api_experiment_log",

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,3 +8,5 @@ pathlib2>=2.3.0
 PyYAML>=6.0.0
 python-dotenv>=1.0.0
 qcodes>=0.36.0
+asyncssh>=2.14.0
+asyncssh>=2.14.0


### PR DESCRIPTION
Add the `remote` module to the qdashboard package to handle remote ssh sessions and job submission.Includes a new settigns dataclass + JSON persistence to ~/.qdashboard/remote_settings.json. Supports four modes: local_slurm / local_direct / remote_slurm / remote_direct.

Connection uses  using asyncssh; supports key file, SSH agent, and ProxyJump; auto-reconnect.